### PR TITLE
Major cleanup, refactor, and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.venv/
+venv/

--- a/README.md
+++ b/README.md
@@ -1,43 +1,72 @@
 # prtg
-Python module to manage PRTG servers
 
-Prerequisites:
-- bs4 (BeautifulSoup)
-- requests
-- lxml
+Python module to manage PRTG servers.
 
-Tested only on Python 3.5.2 so far. Does work with python 2.7 but not extensively tested. 
+## Prerequisites
 
-This is a Python module to facilitate in managing PRTG servers from CLI or for automating changes. It is really useful for scripting changes to prtg objects.
+- Python 3.7+
+- `requests`
+- `beautifulsoup4`
+- `lxml`
+- `urllib3`
 
-The prtg_api no longer uses a config file. Instead you need to enter your PRTG parameters when initiating the prtg_api class. This change was to allow this to be used in a more flexible way, or to manage multiple PRTG instances, you can still set up a local config file for your parameters if you wish. The parameters for initiating the prtg_api class are:
-
-```
-prtg_api(host,user=None,passhash=None,apikey=None,protocol='https',port='443',rootid=0)
-```
-
-Upon initialisation the entire device tree is downloaded and each probe, group, device, sensor and channel is provided as a modifiable object. From the main object (called prtg in example) you can access all objects in the tree using the prtg.allprobes, prtg.allgroups, prtg.alldevices and prtg.allsensors attributes. The channels are not available by default, you must run sensor.get_channels() to the get the child channels of that sensor.
-
-You can also set the root of your sensor tree as a group that is not the root of PRTG. This was added to allow a partial sensortree to be downloaded where your PRTG server may have many objects or to provide access to a user with restricted permissions.
-
-When you are accessing an object further down the tree you only have access to the direct children of that object. This for example will show the devices that are in the 4th group of the allgroups array:
+Install with:
 
 ```
-from prtg import prtg_api
+pip install -r requirements.txt
+```
 
-prtg = prtg_api('192.168.1.1','prtgadmin','0000000000')
-#or with apikey
-prtg = prtg_api('192.168.1.1',apikey='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA======')
+## Overview
+
+This is a Python module to facilitate managing PRTG servers from the CLI or for automating changes. It's useful for scripting changes to PRTG objects.
+
+The module no longer uses a config file. Instead you supply PRTG connection parameters when initialising the `PrtgApi` class. This lets you manage multiple PRTG instances from one script, or wrap the parameters in your own config loader if you prefer. The signature is:
+
+```python
+PrtgApi(
+    host,
+    user=None,
+    passhash=None,
+    apikey=None,
+    rootid=0,
+    protocol='https',
+    port='443',
+    verify_ssl=False,
+    timeout=30.0,
+)
+```
+
+Parameters:
+
+- `host` — PRTG hostname or IP
+- `user`, `passhash` — credentials from PRTG webgui > Settings > Account Settings. Either supply both, or supply `apikey` instead
+- `apikey` — PRTG API token (preferred over user/passhash where available)
+- `rootid` — ID of the group/probe that contains all the objects you want to manage. Defaults to 0 (the entire sensortree)
+- `protocol` — `'http'` or `'https'`
+- `port` — TCP port as a string
+- `verify_ssl` — verify TLS certificates. Defaults to `False` (matches the original module). Set to `True` to opt in to verification.
+- `timeout` — per-request timeout in seconds. Defaults to 30
+
+Upon initialisation the entire sensortree (or the subtree rooted at `rootid`) is downloaded and each probe, group, device, sensor and channel is provided as a modifiable Python object. From the main object (called `prtg` in the examples below) you can access all objects in the tree via `prtg.allprobes`, `prtg.allgroups`, `prtg.alldevices`, and `prtg.allsensors`. Channels are not loaded by default — call `sensor.get_channels()` to populate them.
+
+You can also set the root of your sensor tree to a group that isn't the PRTG root. This is useful when your PRTG server has many objects, or to provide access to a user with restricted permissions. When you access an object further down the tree, you only have access to its direct children. For example, this shows the devices in the 4th group:
+
+```python
+from prtg import PrtgApi
+
+prtg = PrtgApi('192.168.1.1', 'prtgadmin', '0000000000')
+# or with an API key:
+prtg = PrtgApi('192.168.1.1', apikey='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA======')
 
 prtg.allgroups[3].devices
 ```
 
-Probe and group objects can have groups and devices as children, device objects have sensors as children and sensors can have channels as children. 
+Probes and groups can have groups and devices as children; devices have sensors; sensors have channels.
 
-```
-from prtg import prtg_api
+```python
+from prtg import PrtgApi
 
-prtg = prtg_api('192.168.1.1','prtgadmin','0000000000')
+prtg = PrtgApi('192.168.1.1', 'prtgadmin', '0000000000')
 
 probeobject = prtg.allprobes[0]
 groups = probeobject.groups
@@ -52,81 +81,170 @@ sensorobject.get_channels()
 channel = sensorobject.channels[0]
 ```
 
+## Methods
 
-Current methods and parameters (* = required) on all objects include:
-- rename()
-- pause(duration=0,message='') (pause and resume on a channel will change the parent sensor)  
-- resume()
-- clone(newname=''*,newplaceid=''*)
-- delete(confirm=True) (you can't delete the root object or channels)
-- refresh()
-- set_property(name*,value*)
-- get_property(name*)
-- set_additional_param(param*) (for custom script sensors)
-- set_interval(interval*)
-- set_host(host*) (ip address or hostname)
-- search_byid(id)
-- add_tags(['tag1','tag2']*,clear_old=False)
+Methods available on all objects (`*` marks required parameters):
 
-To come:
-- move
+- `rename(newname*)`
+- `pause(duration=0, message='')` — pause/resume on a channel acts on its parent sensor
+- `resume()`
+- `clone(newname*, newplaceid*)` — returns the new object's ID, or `None` if it can't be determined
+- `delete(confirm=True)` — can't delete the root object or channels
+- `refresh()`
+- `set_property(name*, value*)`
+- `get_property(name*)`
+- `set_interval(interval*)`
+- `add_tags(['tag1', 'tag2']*, clear_old=False)`
+- `acknowledge(message='')` — for sensors
+- `save_graph(graphid*, filepath*, size*, hidden_channels='', filetype='svg')`
+- `get_details()` — fetches the JSON sensordata blob
+- `get_historic_data(startdate*, enddate*, timeaverage*)` — historic CSV data; only meaningful on sensors. See [Historic data](#historic-data) below.
 
-If you are making small changes such as pause, resume, rename; the local data will update as you go. If you are doing larger changes you should refresh the data after each change. If you refresh the main prtg object it will refresh everything otherwise you can just refresh an object further down the tree to only refresh part of the local data. To refresh an object call the .refresh() method.
+Device-only:
 
-The set_property method is very powerful and flexible. You can change anything for an object that you can change in the objects settings tab in the web ui. I will add the more commonly used settings as seperate methods. You can use the get_property method to test the name of the property:
+- `set_host(host*)` — IP address or hostname
 
-```
-from prtg import prtg_api
+Sensor-only:
 
-prtg = prtg_api('192.168.1.1','prtgadmin','0000000000')
+- `set_additional_param(param*)` — for custom script sensors
+
+Top-level (`PrtgApi`) only:
+
+- `search_byid(oid*)`
+
+If you make small changes such as pause, resume, or rename, the local data updates as you go. For larger changes, call `.refresh()` afterwards. Refreshing the top-level object refreshes everything; refreshing a child only refreshes that subtree.
+
+`set_property` is powerful: you can change anything for an object that you can change in its Settings tab in the web UI. The common ones are exposed as dedicated methods. Use `get_property` to test a property name first:
+
+```python
+from prtg import PrtgApi
+
+prtg = PrtgApi('192.168.1.1', 'prtgadmin', '0000000000')
 prtg.get_property(name='location')
-#returns the location and sets prtg.location to the result.
+# returns the location and sets prtg.location to the result
 
-prtg.set_property(name='location',value='Canada')
+prtg.set_property(name='location', value='Canada')
 ```
 
-There are delays with some actions such as resuming so you should add time delays where appropriate.
+Some actions (like resume) take time to take effect server-side; add `time.sleep(...)` where appropriate.
 
-example usage:
+## Example
 
-```
+```python
 import time
-from prtg import prtg_api
+from prtg import PrtgApi
 
-prtg = prtg_api('192.168.1.1','prtgadmin','0000000000')
+prtg = PrtgApi('192.168.1.1', 'prtgadmin', '0000000000')
 
-for device in prtg.alldevices:
-  if device.id == "1234":
-    deviceobj = device
+deviceobj = prtg.search_byid("1234")
 
 deviceobj.pause()
-newid = deviceobj.clone(newname="cloned device",newplaceid="2468")
+newid = deviceobj.clone(newname="cloned device", newplaceid="2468")
 
 time.sleep(3)
-
 prtg.refresh()
 
 newdevice = prtg.search_byid(newid)
 newdevice.resume()
-
 ```
 
-The prtg_api class can be used with the root id set as the root group, a probe, or a group. If you wanted to manage a device or sensor and don't want to download the entire sensortree to loop through the results; you can use the prtg_device and prtg_sensor classes. For example:
+## Managing a single device or sensor
 
-```
+If you only want to manage one device or sensor and don't want to download the full sensortree, use `PrtgDevice` or `PrtgSensor`:
+
+```python
+from prtg import PrtgDevice, PrtgSensor
+
 host = '192.168.1.1'
 user = 'prtgadmin'
 passhash = '0000000'
-deviceid = '2025'
 apikey = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA======'
 
-device = prtg_device(host,user=user,passhash=passhash,deviceid=deviceid)
-#or with API Key
-device = prtg_device(host,apikey=apikey,deviceid=deviceid)
+deviceid = '2025'
+device = PrtgDevice(host, user=user, passhash=passhash, deviceid=deviceid)
+# or with API Key
+device = PrtgDevice(host, apikey=apikey, deviceid=deviceid)
 
 sensorid = '2123'
-
-sensor = prtg_device(host,user=user,passhash=passhash,sensorid=sensorid)
-#or with API Key
-sensor = prtg_device(host,apikey=apikey,sensorid=sensorid)
+sensor = PrtgSensor(host, user=user, passhash=passhash, sensorid=sensorid)
+# or with API Key
+sensor = PrtgSensor(host, apikey=apikey, sensorid=sensorid)
 ```
+
+## Historic data
+
+Use `get_historic_data` directly on any sensor object. It returns a dict keyed by column header, with parallel lists of values:
+
+```python
+from datetime import datetime, timedelta
+
+sensor = PrtgSensor(host, apikey=apikey, sensorid='2123')
+
+end = datetime.now()
+start = end - timedelta(hours=24)
+
+data = sensor.get_historic_data(
+    startdate=start,
+    enddate=end,
+    timeaverage=300,  # 5-minute averages
+)
+
+for ts, value in zip(data['Date Time'], data['Traffic In (kbit/s)']):
+    print(ts, value)
+```
+
+Date arguments may be `datetime` instances or pre-formatted `YYYY-MM-DD-HH-MM-SS` strings. `timeaverage` is the averaging interval in seconds (`0` = raw).
+
+**Note:** PRTG returns dates in US format (`MM/DD/YYYY HH:MM:SS AM/PM`) by default; servers with different regional settings may need adjustment in the parser. PRTG also appends a summary footer row (e.g. `"Sums (of 30 values)"`) which the parser detects and skips automatically.
+
+The previous standalone `PrtgHistoricData` class still exists but emits a `DeprecationWarning`. Migrate to `sensor.get_historic_data(...)` when convenient.
+
+## SSL / self-signed certificates
+
+`verify_ssl` defaults to `False` (matching the original module's behaviour — PRTG installs commonly use self-signed certs or chains that `requests` doesn't accept). Pass `verify_ssl=True` to opt in to certificate verification:
+
+```python
+prtg = PrtgApi('192.168.1.1', apikey='...', verify_ssl=True)
+```
+
+When `verify_ssl=False` the urllib3 `InsecureRequestWarning` is also suppressed for the process.
+
+If your PRTG server has a valid cert but `requests` rejects it, the most common cause is a missing intermediate certificate in the server's chain — browsers fix this automatically by fetching the intermediate, but `requests` doesn't. Run `openssl s_client -connect yourprtg:443 -showcerts` to check the chain.
+
+## Notes
+
+- Past versions used class names like `prtg_api`, `prtg_device`, `prtg_sensor`. These have been renamed to PEP-8 PascalCase: `PrtgApi`, `PrtgDevice`, `PrtgSensor`. **The old names still work as drop-in aliases** but emit `DeprecationWarning` on construction — use them as TODO markers to update your scripts at your own pace. The aliases will be removed in a future release.
+- All requests now have a configurable timeout (default 30 s). A hung PRTG server will raise `PrtgError` instead of blocking forever.
+- All API calls now use proper URL parameter encoding, so values with `&`, spaces, or unicode (in tag names, pause messages, etc.) round-trip correctly.
+
+## Repo layout
+
+```
+prtg/
+├── prtg.py             # the module
+├── README.md
+├── requirements.txt
+├── tests/
+│   └── test_prtg.py    # mocked unit tests
+└── clone_probe.py      # standalone diagnostic for the clone() endpoint
+```
+
+## Running tests
+
+The repo includes a unittest suite that mocks the HTTP layer — no live PRTG server needed. From the repo root:
+
+```
+python -m unittest discover tests
+```
+
+or with pytest:
+
+```
+pytest tests/
+```
+
+The tests cover URL parameter encoding, sensortree parsing, refresh reconciliation, the historic-data CSV parser (including the summary-footer-skip case), and the multi-shape `clone()` id extraction.
+
+## To come
+
+- `move`

--- a/prtg.py
+++ b/prtg.py
@@ -1,722 +1,1292 @@
-import os
+"""
+Python module to manage PRTG servers via the HTTP API.
+
+Provides object-oriented access to the PRTG sensor tree: probes, groups,
+devices, sensors and channels. Each object exposes methods to query and
+mutate its corresponding PRTG resource (rename, pause, clone, set
+properties, delete, etc.).
+
+Typical use:
+
+    from prtg import PrtgApi
+
+    prtg = PrtgApi(
+        host="prtg.example.com",
+        user="prtgadmin",
+        passhash="0000000",
+        rootid=0,
+    )
+
+    for probe in prtg.probes:
+        print(probe)
+"""
+
+from __future__ import annotations
+
 import csv
-import requests
-import warnings
 import json
-from datetime import datetime,timedelta
-from bs4 import BeautifulSoup,XMLParsedAsHTMLWarning
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
+import logging
+import urllib3
+from datetime import datetime
+from typing import Any, Iterable, NamedTuple
 
-warnings.filterwarnings('ignore', category=XMLParsedAsHTMLWarning)
+import requests
+from bs4 import BeautifulSoup
 
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-
-#class used by prtg_api and children to manage global arrays of all objects
-class global_arrays(object):
-    allprobes = []
-    allgroups = []
-    alldevices = []
-    allsensors = []
+log = logging.getLogger(__name__)
 
 
-#class used by all prtg_* objects to build urls and query prtg using requests   
-class connection_methods(object):
-    def unpack_config(self,confdata):
-        self.host = confdata[0]
-        self.port = confdata[1]
-        self.user = confdata[2]
-        self.passhash = confdata[3]
-        self.protocol = confdata[4]
-        self.apikey = confdata[5]
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class PrtgError(Exception):
+    """Base class for all PRTG-related errors."""
+
+
+class AuthenticationError(PrtgError):
+    """Authentication with the PRTG server failed."""
+
+
+class ResourceNotFound(PrtgError):
+    """The requested PRTG resource was not found."""
+
+
+class MalformedRequest(PrtgError):
+    """PRTG rejected the request as malformed."""
+
+
+# ---------------------------------------------------------------------------
+# Connection config
+# ---------------------------------------------------------------------------
+
+
+class ConfData(NamedTuple):
+    """Connection configuration passed between objects."""
+
+    host: str
+    port: str
+    user: str | None
+    passhash: str | None
+    protocol: str
+    apikey: str | None
+    verify_ssl: bool
+    timeout: float
+
+
+class ConnectionMethods:
+    """Mixin providing URL building and HTTP request handling."""
+
+    confdata: ConfData
+
+    def unpack_config(self, confdata: ConfData) -> None:
         self.confdata = confdata
-        self.base_url = "{protocol}://{host}:{port}/api/".format(protocol=self.protocol,host=self.host,port=self.port)
-        self.base_url_no_api = "{protocol}://{host}:{port}/".format(protocol=self.protocol,host=self.host,port=self.port)
+        self.host = confdata.host
+        self.port = confdata.port
+        self.user = confdata.user
+        self.passhash = confdata.passhash
+        self.protocol = confdata.protocol
+        self.apikey = confdata.apikey
+        self.verify_ssl = confdata.verify_ssl
+        self.timeout = confdata.timeout
+
+        self.base_url = f"{self.protocol}://{self.host}:{self.port}/api/"
+        self.base_url_no_api = f"{self.protocol}://{self.host}:{self.port}/"
+
         if self.user is None and self.passhash is None and self.apikey is None:
-            raise(self.AuthenticationError("Please supply username & passhash or api key"))
-        elif self.apikey is None:
-            if self.user is None or self.passhash is None:
-                raise(self.AuthenticationError("Please supply both username & passhash"))
+            raise AuthenticationError(
+                "Please supply username & passhash or api key"
+            )
+        if self.apikey is None and (self.user is None or self.passhash is None):
+            raise AuthenticationError(
+                "Please supply both username & passhash"
+            )
+
+        if not self.verify_ssl:
+            # Suppress the InsecureRequestWarning per-process when the user
+            # has opted in to skipping cert verification.
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    def _auth_params(self) -> dict[str, str]:
         if self.apikey is not None:
-            self.url_auth = "apitoken={apitoken}".format(apitoken=self.apikey)
-        else:
-            self.url_auth = "username={username}&passhash={passhash}".format(username=self.user,passhash=self.passhash)
-    def get_request(self,url_string,api=True):
-        #global method for api calls. Provides errors for the 400, 401 and 404 responses
-        if api:
-            url = "{base}{content}&{auth}".format(base=self.base_url,content=url_string,auth=self.url_auth)
-        else:
-            url = "{base}{content}&{auth}".format(base=self.base_url_no_api,content=url_string,auth=self.url_auth)
-        req = requests.get(url,verify=False)
-        if req.status_code == 200 or req.status_code == 302:
-            return(req)
-        elif req.status_code == 401:
-            raise(self.AuthenticationError("PRTG authentication failed. Check credentials in config file"))
-        elif req.status_code == 404:
-            raise(self.ResourceNotFound("No resource at URL used: {0}".format(url_string)))
-        elif req.status_code == 400:
-            raise(self.MalformedRequest("Request was rejected by prtg. {0}".format(url_string)))
-        else:
-            raise(Exception("Unexpected requests status code: {sc}. \nReturned error: {er}".format(sc=req.status_code,er=req.text)))
+            return {"apitoken": self.apikey}
+        return {"username": self.user, "passhash": self.passhash}
+
+    def get_request(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+        api: bool = True,
+        check_login_page: bool = True,
+    ) -> requests.Response:
+        """Issue a GET against the PRTG server.
+
+        ``path`` is the endpoint relative to ``/api/`` (or to root when
+        ``api=False``). ``params`` is the query string as a dict — values
+        are URL-encoded automatically by requests, so callers don't need
+        to worry about special characters.
+
+        ``check_login_page`` controls whether a 200 response landing on
+        ``/public/login.htm`` is treated as an auth failure. Set to False
+        for endpoints (like ``duplicateobject.htm``) whose success response
+        legitimately lands on a login page with the result embedded in the URL.
+        """
+        base = self.base_url if api else self.base_url_no_api
+        url = f"{base}{path}"
+        all_params = {**(params or {}), **self._auth_params()}
+
+        try:
+            req = requests.get(
+                url,
+                params=all_params,
+                verify=self.verify_ssl,
+                timeout=self.timeout,
+            )
+        except requests.exceptions.Timeout as exc:
+            raise PrtgError(
+                f"Request to {path} timed out after {self.timeout}s"
+            ) from exc
+        except requests.exceptions.ConnectionError as exc:
+            raise PrtgError(f"Connection to PRTG failed: {exc}") from exc
+
+        if req.status_code in (200, 302):
+            if check_login_page and self._looks_like_login_page(req):
+                raise AuthenticationError(
+                    "PRTG returned a login page — credentials likely invalid "
+                    "or session expired"
+                )
+            return req
+        if req.status_code == 401:
+            raise AuthenticationError(
+                "PRTG authentication failed. Check credentials in config file"
+            )
+        if req.status_code == 404:
+            raise ResourceNotFound(f"No resource at URL used: {path}")
+        if req.status_code == 400:
+            raise MalformedRequest(f"Request was rejected by prtg. {path}")
+        raise PrtgError(
+            f"Unexpected response status {req.status_code}: {req.text}"
+        )
+
+    @staticmethod
+    def _looks_like_login_page(req: requests.Response) -> bool:
+        """Detect PRTG's 200-with-login-page-body auth failure response."""
+        return "/public/login.htm" in req.url
 
 
-class baseconfig(connection_methods):
-    def __str__(self):
-        return("<Name: {name}, ID: {id}, Active: {active}>".format(name=self.name,id=self.id,active=self.active))
-    def __repr__(self):
-        return("<Name: {name}, ID: {id}, Active: {active}>".format(name=self.name,id=self.id,active=self.active))
-    def clear_arrays(self):
-        del self.allprobes[:]
-        del self.allgroups[:]
-        del self.alldevices[:]
-        del self.allsensors[:]
-    def delete(self,confirm=True):
+# ---------------------------------------------------------------------------
+# Shared state
+# ---------------------------------------------------------------------------
+
+
+class GlobalArrays:
+    """Holds flat lists of every object discovered in the sensor tree.
+
+    NOTE: these are class-level attributes so that all objects spawned
+    from a single ``PrtgApi`` instance share the same registry. If you
+    instantiate ``PrtgApi`` against more than one PRTG server in the
+    same process, the lists will be shared between them; clearing one
+    clears all. Call ``clear_arrays()`` on a fresh instance to reset.
+    """
+
+    allprobes: list = []
+    allgroups: list = []
+    alldevices: list = []
+    allsensors: list = []
+
+
+# ---------------------------------------------------------------------------
+# Base config (shared methods for all PRTG objects)
+# ---------------------------------------------------------------------------
+
+
+class BaseConfig(ConnectionMethods):
+    """Shared behaviour for every PRTG object (probe/group/device/sensor)."""
+
+    name: str = ""
+    id: str = ""
+    active: str = ""
+    type: str = ""
+
+    def __repr__(self) -> str:
+        cls = type(self).__name__
+        return (
+            f"<{cls} name={self.name!r} id={self.id} active={self.active}>"
+        )
+
+    def clear_arrays(self) -> None:
+        del GlobalArrays.allprobes[:]
+        del GlobalArrays.allgroups[:]
+        del GlobalArrays.alldevices[:]
+        del GlobalArrays.allsensors[:]
+
+    def delete(self, confirm: bool = True) -> None:
+        """Delete this object from PRTG.
+
+        If ``confirm`` is True the user is prompted at the terminal. Raises
+        ``PrtgError`` if called on the root object.
+        """
         if self.type == "Root":
-            return("You cannot delete the root object.")
-        else:
-            delete_url = "deleteobject.htm?id={objid}&approve=1".format(objid=self.id)
-            if confirm:
-                response = ""
-                while response.upper() not in ["Y","N"]:
-                    response = str(input("Would you like to continue?(Y/[N])  "))
-                    if response == "":
-                        response = "N"
-                if response.upper() == "Y":
-                    req = self.get_request(url_string=delete_url)
-            else:
-                req = self.get_request(url_string=delete_url)
-    def set_property(self,name,value):
+            raise PrtgError("You cannot delete the root object.")
+
+        if confirm:
+            response = ""
+            while response.upper() not in ("Y", "N"):
+                response = input("Would you like to continue? (Y/[N]) ") or "N"
+            if response.upper() != "Y":
+                log.info("Delete aborted by user for id=%s", self.id)
+                return
+
+        self.get_request(
+            "deleteobject.htm",
+            params={"id": self.id, "approve": 1},
+        )
+
+    def set_property(self, name: str, value: Any) -> None:
         if self.type != "Channel":
-            setprop_url = "setobjectproperty.htm?id={objid}&name={propname}&value={propval}".format(objid=self.id,propname=name,propval=value)
+            params = {"id": self.id, "name": name, "value": value}
         else:
-            setprop_url = "setobjectproperty.htm?id={objid}&subtype=channel&subid={subid}&name={propname}&value={propval}".format(objid=self.sensorid,subid=self.objid,propname=name,propval=value)
-        req = self.get_request(url_string=setprop_url)
-        setattr(self,name,value)
-    def get_property(self,name):
+            params = {
+                "id": self.sensorid,
+                "subtype": "channel",
+                "subid": self.objid,
+                "name": name,
+                "value": value,
+            }
+        self.get_request("setobjectproperty.htm", params=params)
+        setattr(self, name, value)
+
+    def get_property(self, name: str) -> str:
         if self.type != "Channel":
-            getprop_url = "getobjectproperty.htm?id={objid}&name={propname}&show=text".format(objid=self.id,propname=name)
+            params = {"id": self.id, "name": name, "show": "text"}
         else:
-            getprop_url = "getobjectproperty.htm?id={objid}&subtype=channel&subid={subid}&name={propname}".format(objid=self.sensorid,subid=self.objid,propname=name)
-        req = self.get_request(url_string=getprop_url)
-        soup = BeautifulSoup(req.text,'lxml')
-        if soup.result.text != "(Property not found)":
-            setattr(self,name,soup.result.text)
-            return(soup.result.text)
-        else:
-            raise(self.ResourceNotFound("No object property of name: {name}".format(name=name)))
-    def set_interval(self,interval):
-        '''note: you will still need to disable inheritance manually.
-        Valid intervals are (seconds): 30, 60, 300, 600, 900, 1800, 3600, 14400, 21600, 43200, 86400'''
-        self.set_property(name="interval",value=interval)
-    def get_tree(self,root=''):
-        #gets sensortree from prtg. If no rootid is provided returns entire tree
-        tree_url = "table.xml?content=sensortree&output=xml&id={rootid}".format(rootid=root)
-        req = self.get_request(url_string=tree_url)
-        raw_data = req.text
-        treesoup = BeautifulSoup(raw_data,"lxml")
-        #returns the xml as a beautifulsoup object
-        if len(treesoup.sensortree.nodes) > 0:
-            return(treesoup)
-        else:
-            raise(self.ResourceNotFound("No objects at ID: {id}".format(id=root)))
-    def rename(self,newname):
-        rename_url = "rename.htm?id={objid}&value={name}".format(objid=self.id,name=newname)
-        req = self.get_request(url_string=rename_url)
+            params = {
+                "id": self.sensorid,
+                "subtype": "channel",
+                "subid": self.objid,
+                "name": name,
+            }
+        req = self.get_request("getobjectproperty.htm", params=params)
+        soup = BeautifulSoup(req.text, "xml")
+        text = soup.result.text
+        if text == "(Property not found)":
+            raise ResourceNotFound(f"No object property of name: {name}")
+        setattr(self, name, text)
+        return text
+
+    def set_interval(self, interval: int) -> None:
+        """Set the scanning interval (seconds).
+
+        Note: inheritance must still be disabled manually in the PRTG UI.
+        Valid intervals: 30, 60, 300, 600, 900, 1800, 3600, 14400, 21600,
+        43200, 86400.
+        """
+        self.set_property(name="interval", value=interval)
+
+    def get_tree(self, root: str | int = "") -> BeautifulSoup:
+        """Fetch the sensortree XML from PRTG starting at ``root``."""
+        req = self.get_request(
+            "table.xml",
+            params={"content": "sensortree", "output": "xml", "id": root},
+        )
+        treesoup = BeautifulSoup(req.text, "xml")
+        if not treesoup.sensortree.nodes.find(True):
+            raise ResourceNotFound(f"No objects at ID: {root}")
+        return treesoup
+
+    def rename(self, newname: str) -> None:
+        self.get_request(
+            "rename.htm",
+            params={"id": self.id, "value": newname},
+        )
         self.name = newname
-    def pause(self,duration=0,message=""):
+
+    def pause(self, duration: int = 0, message: str = "") -> None:
         if duration > 0:
-            pause_url = "pauseobjectfor.htm?id={objid}&duration={time}".format(objid=self.id,time=str(duration))
+            path = "pauseobjectfor.htm"
+            params: dict[str, Any] = {"id": self.id, "duration": duration}
         else:
-            pause_url = "pause.htm?id={objid}&action=0".format(objid=self.id)
+            path = "pause.htm"
+            params = {"id": self.id, "action": 0}
         if message:
-            pause_url += "&pausemsg={string}".format(string=message)
-        req = self.get_request(url_string=pause_url)
+            params["pausemsg"] = message
+        self.get_request(path, params=params)
         self.status = "Paused"
         self.active = "false"
         self.status_raw = "7"
-    def resume(self):
-        resume_url = "pause.htm?id={objid}&action=1".format(objid=self.id)
-        req = self.get_request(url_string=resume_url)
-        #these are question marks because we don't know what status is after resume
+
+    def resume(self) -> None:
+        self.get_request(
+            "pause.htm",
+            params={"id": self.id, "action": 1},
+        )
+        # Status is indeterminate immediately after resume.
         self.status = "?"
         self.active = "true"
         self.status_raw = "?"
-    def get_status(self, name="status"):
-        status_url= "getobjectstatus.htm?id={objid}&name={name}&show=text".format(objid=self.id, name=name)
-        req = self.get_request(url_string=status_url)
-        soup = BeautifulSoup(req.text,'lxml')
+
+    def get_status(self, name: str = "status") -> str:
+        req = self.get_request(
+            "getobjectstatus.htm",
+            params={"id": self.id, "name": name, "show": "text"},
+        )
+        soup = BeautifulSoup(req.text, "xml")
         status = soup.result.text.strip()
         self.status = status
-        return(status)
-    def clone(self,newname,newplaceid):
-        clone_url = "duplicateobject.htm?id={objid}&name={name}&targetid={newparent}".format(objid=self.id,name=newname,newparent=newplaceid)
-        req = self.get_request(url_string=clone_url)
+        return status
+
+    def clone(self, newname: str, newplaceid: str) -> str | None:
+        """Duplicate this object and return the new object's id.
+
+        PRTG's response shape for ``duplicateobject.htm`` has varied across
+        versions. We've seen:
+
+        1. A 302 redirect to ``/object.htm?id=<newid>`` — the modern,
+           documented behaviour. ``req.history`` is populated.
+        2. A 200 response with no redirect, but ``req.url`` containing
+           ``/public/login.htm?loginurl=/object.htm?id=<newid>&errormsg=``
+           (Paessler KB confirms this happens on some configurations).
+        3. A 200 with only progress info and no usable id (older versions).
+
+        This method handles 1 and 2 and returns ``None`` for 3 so callers
+        can detect failure rather than crash.
+        """
+        req = self.get_request(
+            "duplicateobject.htm",
+            params={
+                "id": self.id,
+                "name": newname,
+                "targetid": newplaceid,
+            },
+            check_login_page=False,
+        )
         if req is None:
-            return(None)
+            return None
+        return _extract_new_id(req)
+
+    def add_tags(self, tags: list[str], clear_old: bool = False) -> None:
+        if not isinstance(tags, list):
+            raise TypeError("tags must be a list")
+        old_tags = [] if clear_old else self.get_property("tags").split(" ")
+        # Preserve order and dedup
+        merged = list(dict.fromkeys(t for t in old_tags + tags if t))
+        self.set_property(name="tags", value=" ".join(merged))
+
+    def acknowledge(self, message: str = "") -> None:
+        """Acknowledge an alarm on this object."""
+        self.get_request(
+            "acknowledgealarm.htm",
+            params={"id": self.id, "ackmsg": message},
+        )
+
+    def save_graph(
+        self,
+        graphid: str,
+        filepath: str,
+        size: str,
+        hidden_channels: str = "",
+        filetype: str = "svg",
+    ) -> None:
+        """Download a graph image for this object. Size options: S, M, L."""
+        width, height, font = _graph_dimensions(size)
+        params: dict[str, Any] = {
+            "type": "graph",
+            "graphid": graphid,
+            "id": self.id,
+            "width": width,
+            "height": height,
+            "plotcolor": "#ffffff",
+            "gridcolor": "#ffffff",
+            "graphstyling": f"showLegend='1' baseFontSize='{font}'",
+        }
+        if hidden_channels:
+            params["hide"] = hidden_channels
+
+        try:
+            req = requests.get(
+                f"{self.base_url_no_api}chart.{filetype}",
+                params={**params, **self._auth_params()},
+                verify=self.verify_ssl,
+                stream=True,
+                timeout=self.timeout,
+            )
+        except requests.exceptions.Timeout as exc:
+            raise PrtgError(
+                f"save_graph timed out after {self.timeout}s"
+            ) from exc
+
+        req.raise_for_status()
+        with open(filepath, "wb") as imgfile:
+            for chunk in req.iter_content(chunk_size=8192):
+                imgfile.write(chunk)
+        self.filepath = filepath
+
+    def get_details(self) -> None:
+        """Fetch the JSON sensordata blob and store it on ``self.details``."""
+        req = self.get_request(
+            "getsensordetails.json",
+            params={"id": self.id},
+        )
+        self.details = json.loads(req.text)["sensordata"]
+
+    def get_historic_data(
+        self,
+        startdate: datetime | str,
+        enddate: datetime | str,
+        timeaverage: int,
+    ) -> dict[str, list]:
+        """Fetch historic data for this object between two timestamps.
+
+        Date arguments may be ``datetime`` instances or pre-formatted
+        ``YYYY-MM-DD-HH-MM-SS`` strings. ``timeaverage`` is the averaging
+        interval in seconds (0 = raw).
+
+        Returns a dict keyed by column header, with parallel lists of
+        values. The ``Date Time`` column is parsed as US-format
+        ``MM/DD/YYYY HH:MM:SS AM/PM``, matching PRTG's CSV default.
+        Servers configured for other regional formats will require
+        adjustment.
+
+        Note: PRTG only returns meaningful historic data for sensors
+        (and in some versions, channels). Calling this on a group/device
+        will likely return an empty result or an error from PRTG.
+        """
+        if isinstance(startdate, datetime):
+            startdate = _format_prtg_date(startdate)
+        if isinstance(enddate, datetime):
+            enddate = _format_prtg_date(enddate)
+
+        req = self.get_request(
+            "historicdata.csv",
+            params={
+                "id": self.id,
+                "avg": timeaverage,
+                "sdate": startdate,
+                "edate": enddate,
+            },
+        )
+        return _parse_historic_csv(req.text)
+
+
+# ---------------------------------------------------------------------------
+# Tree reconciliation helper
+# ---------------------------------------------------------------------------
+
+
+def _reconcile_children(
+    candidates: Iterable,
+    existing: list,
+    factory,
+    all_list: list | None = None,
+    id_of_soup=lambda c: c.find("id").string,
+) -> None:
+    """Refresh ``existing`` against ``candidates`` BeautifulSoup nodes.
+
+    For each candidate: refresh the matching object if present, otherwise
+    create one via ``factory(childsoup)`` and append it to both ``existing``
+    and ``all_list`` (when provided). Any object in ``existing`` whose id
+    is no longer in ``candidates`` is removed from both lists.
+    """
+    existing_by_id = {obj.id: obj for obj in existing}
+    seen: set[str] = set()
+
+    for childsoup in candidates:
+        cid = id_of_soup(childsoup)
+        seen.add(cid)
+        match = existing_by_id.get(cid)
+        if match is not None:
+            match.refresh(childsoup)
         else:
-            new_url = req.history[-1].url
-            new_id = new_url.split('=')[-1]
-            return(new_id)
-    def add_tags(self,tags,clear_old=False):
-        if not isinstance(tags,list):
-            raise(Exception("Needs tags as type: list"))
-        if clear_old:
-            old_tags = []
-        else:
-            old_tags = self.get_property('tags').split(' ')
-        new_tags = " ".join(old_tags+tags)
-        self.set_property(name='tags',value=new_tags)
-    #define global arrays, inherited to all objects
-    class AuthenticationError(Exception):
-        pass
-    class ResourceNotFound(Exception):
-        pass
-    class MalformedRequest(Exception):
-        pass
+            new = factory(childsoup)
+            existing.append(new)
+            if all_list is not None and all_list is not existing:
+                all_list.append(new)
+
+    for obj in list(existing):
+        if obj.id not in seen:
+            existing.remove(obj)
+            if all_list is not None and all_list is not existing and obj in all_list:
+                all_list.remove(obj)
 
 
-class prtg_api(global_arrays,baseconfig):
-    '''
-    Parameters:
-    - host: Enter the ip address or hostname where PRTG is running
-    - port: Enter the tcp port used to connect to prtg. (usually 80 or 443)
-    - user: Enter your PRTG username
-    - passhash: Enter your PRTG passhash. Can be found in PRTG webgui > settings > account settings
-    - protocol: Enter the protocol used to connect to PRTG server (http or https)
-    - rootid: Enter the id of the group/probe that contains all the objects you want to manage. Defaults to 0 (gets entire sensortree)
-    
-    Example:
-    host = '192.168.1.1'
-    port = '443'
-    user = 'prtgadmin'
-    passhash = '0000000'
-    protocol = 'https'
-    rootid = '53'
-    prtg = prtg_api(host,user,passhash,rootid,protocol,port)
-    '''
-    def __init__(self,host,user=None,passhash=None,apikey=None,rootid=0,protocol='https',port='443'):
-        self.confdata = (host,port,user,passhash,protocol,apikey)
-        self.unpack_config(self.confdata)
-        self.clear_arrays()
-        self.probes = []
-        self.groups = []
-        self.devices = []
-        #get sensortree from root id downwards
-        self.treesoup = self.get_tree(root=rootid)
-        #Finds all the direct child nodes in sensortree and creates python objects, passes each object its xml data
-        for child in self.treesoup.sensortree.nodes.children:
-            if child.name is not None:
-                for childr in child.children:
-                    if childr.name == "probenode":
-                        probeobj = probe(childr,self.confdata)
-                        self.allprobes.append(probeobj)
-                        self.probes.append(probeobj)
-                    elif childr.name == "device":
-                        deviceobj = device(childr,self.confdata)
-                        self.devices.append(deviceobj)
-                        self.alldevices.append(deviceobj)
-                    elif childr.name == "group":
-                        groupobj = group(childr,self.confdata)
-                        self.groups.append(groupobj)
-                        self.allgroups.append(groupobj)
-                    elif childr.name is not None:
-                        if childr.string is None:
-                            childr.string = ""
-                        setattr(self,childr.name,childr.string)
-    def refresh(self):
-        #download fresh sensortree
-        self.treesoup = self.get_tree(root=self.id)
-        probeids = []
-        newprobeids = []
-        groupids = []
-        newgroupids = []
-        deviceids = []
-        newdeviceids = []
-        #get ids of existing probes
-        for aprobe in self.probes:
-            probeids.append(aprobe.id)
-        for agroup in self.groups:
-            groupids.append(agroup.id)
-        for adevice in self.devices:
-            deviceids.append(adevice.id)
-        #for all the child objects in sensortree, if it already exists refresh the object, otherwise create a new one   
-        for child in self.treesoup.sensortree.nodes.children:
-            if child.name is not None:
-                for childr in child.children:
-                    if childr.name == "probenode":
-                        if childr.find("id").string in probeids:
-                            for aprobe in self.probes:
-                                if aprobe.id == childr.find("id").string:
-                                    aprobe.refresh(childr)
-                        else:
-                            probeobj = probe(childr,self.confdata)
-                            self.probes.append(probeobj)
-                            self.allprobes.append(probeobj)
-                        #add all probe ids from the sensortree to this list
-                        newprobeids.append(childr.find("id").string)
-                    elif childr.name == "group":
-                        if childr.find("id").string in groupids:
-                            for agroup in self.groups:
-                                if agroup.id == childr.find("id").string:
-                                    agroup.refresh(childr)
-                        else:
-                            groupobj = group(childr,self.confdata)
-                            self.allgroups.append(groupobj)
-                            self.groups.append(groupobj)
-                        #add all probe ids from the sensortree to this list
-                        newgroupids.append(childr.find("id").string)
-                    elif childr.name == "device":
-                        if childr.find("id").string in deviceids:
-                            for adevice in self.devices:
-                                if adevice.id == childr.find("id").string:
-                                    adevice.refresh(childr)
-                        else:
-                            deviceobj = device(childr,self.confdata)
-                            self.alldevices.append(deviceobj)
-                            self.devices.append(deviceobj)
-                        #add all probe ids from the sensortree to this list
-                        newdeviceids.append(childr.find("id").string)
-                    elif childr.name is not None:
-                        if childr.string is None:
-                            childr.string = ""
-                        setattr(self,childr.name,childr.string)
-        #if existing probes were not in the new sensortree, remove from allprobes
-        for id in probeids:
-            if id not in newprobeids:
-                for aprobe in self.probes:
-                    if aprobe.id == id:
-                        self.allprobes.remove(aprobe)
-                        self.probes.remove(aprobe)
-        for id in groupids:
-            if id not in newgroupids:
-                for agroup in self.groups:
-                    if agroup.id == id:
-                        self.allgroups.remove(agroup)
-                        self.groups.remove(agroup)
-        for id in deviceids:
-            if id not in newdeviceids:
-                for adevice in self.devices:
-                    if adevice.id == id:
-                        self.alldevice.remove(adevice)
-                        self.devices.remove(adevice)
-    def search_byid(self,id):
-        id = str(id)
-        for obj in self.allprobes + self.allgroups + self.alldevices + self.allsensors:
-            if obj.id == id:
-                return(obj)
+def _iter_named_children(parent_soup):
+    """Yield direct children of a soup node that are real tags (not whitespace)."""
+    for child in parent_soup.children:
+        if child.name is not None:
+            yield child
 
 
-class channel(prtg_api):
-    def __init__(self,channelsoup,sensorid,confdata):
+def _absorb_simple_children(obj, soup) -> None:
+    """Copy text-only children of ``soup`` onto ``obj`` as attributes.
+
+    Used by every object's parser: any direct child that isn't itself a
+    nested PRTG object becomes a string attribute on the parent.
+    """
+    for child in _iter_named_children(soup):
+        if child.string is None:
+            child.string = ""
+        setattr(obj, child.name, child.string)
+
+
+def _extract_new_id(req: requests.Response) -> str | None:
+    """Extract the new object id from a ``duplicateobject.htm`` response.
+
+    PRTG's redirect chain after a successful clone varies considerably:
+
+    * **Classic local-login setup**: ``duplicateobject.htm`` → 302 to
+      ``object.htm?id=NNN`` (or ``sensor.htm?id=NNN``).
+    * **SSO setup (e.g. Azure AD)**: longer chain that goes via
+      ``sensor.htm?id=NNN`` → ``login.htm?loginurl=/sensor.htm?id=NNN``
+      → IdP → callback → ``local_login.htm?loginurl=/sensor.htm?id=NNN``.
+
+    The new id is **always** present somewhere in the chain (either as
+    ``?id=NNN`` directly or embedded in a ``loginurl`` parameter), but
+    we have to walk multiple URLs to find it reliably.
+
+    Strategy: collect every URL touched during the redirect chain
+    (history entries + final req.url) and check each for the new id.
+    Prefer URLs that look like an object page (sensor/device/group/object)
+    over login pages, because the login pages are auth-failure
+    artifacts that don't always survive.
+    """
+    from urllib.parse import urlparse, parse_qs, unquote
+
+    # Collect every URL from the chain. Order matters: we walk early URLs
+    # (most likely the direct sensor.htm redirect from PRTG) before late
+    # URLs (SSO callbacks that may not carry the id).
+    urls = [h.url for h in req.history] + [req.url]
+
+    # Filter to URLs that contain *some* id reference, then prefer object
+    # URLs over login URLs.
+    def _is_object_url(url: str) -> bool:
+        path = urlparse(url).path
+        return any(
+            page in path
+            for page in ("sensor.htm", "device.htm", "group.htm", "object.htm", "probe.htm")
+        )
+
+    ordered = [u for u in urls if _is_object_url(u)] + [
+        u for u in urls if not _is_object_url(u)
+    ]
+
+    for url in ordered:
+        parsed = urlparse(url)
+        qs = parse_qs(parsed.query)
+
+        # Strategy A: direct ?id=NNN. The request URL also contains
+        # ?id=<source-id>, so we need to skip URLs that look like the
+        # original duplicateobject request.
+        if "duplicateobject" not in parsed.path:
+            if "id" in qs and qs["id"][0].isdigit():
+                return qs["id"][0]
+
+        # Strategy B: loginurl=/object.htm?id=NNN&...
+        if "loginurl" in qs:
+            inner = urlparse(unquote(qs["loginurl"][0]))
+            inner_qs = parse_qs(inner.query)
+            if "id" in inner_qs and inner_qs["id"][0].isdigit():
+                return inner_qs["id"][0]
+
+    return None
+
+
+def _graph_dimensions(size: str) -> tuple[str, str, str]:
+    """Return (width, height, font) tuple for size code S/M/L."""
+    sizes = {
+        "L": ("1500", "500", "13"),
+        "S": ("400", "300", "9"),
+    }
+    return sizes.get(size.upper(), ("800", "350", "13"))
+
+
+def _parse_historic_csv(text: str) -> dict[str, list]:
+    """Parse a PRTG ``historicdata.csv`` payload into per-column lists.
+
+    Handles two PRTG quirks:
+
+    * The ``Date Time`` cell may have a trailing ``" - <interval>"``
+      annotation that needs stripping before strptime.
+    * PRTG appends a summary footer row whose ``Date Time`` cell reads
+      something like ``"Sums (of 30 values)"`` or
+      ``"Averages (of N values)"``. That row has no parseable timestamp;
+      we detect it by trying strptime on the date cell and skip the
+      entire row if parsing fails. This keeps the per-column lists
+      aligned and avoids the partial-append misalignment the original
+      try/except path created.
+
+    Dates are parsed as US-format (``%m/%d/%Y %I:%M:%S %p``), matching
+    PRTG's default CSV output. Servers configured for other regional
+    formats will require adjustment.
+    """
+    lines = [l for l in text.splitlines() if l.strip()]
+    reader = csv.reader(lines)
+
+    data: dict[str, list] = {}
+    headers: list[str] = []
+    datetime_idx: int | None = None
+
+    for i, row in enumerate(reader):
+        if i == 0:
+            headers = row
+            for header in headers:
+                data[header] = []
+            datetime_idx = (
+                headers.index("Date Time") if "Date Time" in headers else None
+            )
+            continue
+
+        # Skip footer rows whose Date Time cell isn't a parseable timestamp
+        # (e.g. "Sums (of 30 values)").
+        if datetime_idx is not None and datetime_idx < len(row):
+            cell = row[datetime_idx]
+            if " -" in cell:
+                cell = cell[: cell.index(" -")]
+            try:
+                datetime.strptime(cell, "%m/%d/%Y %I:%M:%S %p")
+            except ValueError:
+                continue
+
+        for j, cell in enumerate(row):
+            if headers[j] == "Date Time":
+                if " -" in cell:
+                    cell = cell[: cell.index(" -")]
+                data[headers[j]].append(
+                    datetime.strptime(cell, "%m/%d/%Y %I:%M:%S %p")
+                )
+            else:
+                data[headers[j]].append(cell)
+    return data
+
+
+def _format_prtg_date(dateobj: datetime) -> str:
+    """Format a datetime in the form PRTG expects: YYYY-MM-DD-HH-MM-SS."""
+    return dateobj.strftime("%Y-%m-%d-%H-%M-%S")
+
+
+# ---------------------------------------------------------------------------
+# Channel
+# ---------------------------------------------------------------------------
+
+
+class Channel(BaseConfig, GlobalArrays):
+    type = "Channel"
+
+    def __init__(self, channelsoup, sensorid: str, confdata: ConfData) -> None:
         self.unpack_config(confdata)
         self.sensorid = sensorid
-        for child in channelsoup.children:
-            if child.string is None:
-                child.string = ""
-            if child.name is not None:
-                setattr(self,child.name,child.string)
+        _absorb_simple_children(self, channelsoup)
         self.id = self.objid
-        if hasattr(self,'lastvalue'):
-            if self.lastvalue.replace(".","").isdigit():
-                try:
-                    self.lastvalue_int = int(self.lastvalue.split(" ")[0].replace(",",""))
-                    self.lastvalue_float = float(self.lastvalue_int)
-                except ValueError:
-                    self.lastvalue_float = float(self.lastvalue.split(" ")[0].replace(",",""))
-                    self.lastvalue_int = int(self.lastvalue_float)
-                self.unit = self.lastvalue.split(" ")[1]
-        self.type = "Channel"
-    def __str__(self):
-        return("<Name: {name}, ID: {id}>".format(name=self.name,id=self.id))
-    def __repr__(self):
-        return("<Name: {name}, ID: {id}>".format(name=self.name,id=self.id))
-    def rename(self,newname):
-        self.set_property(name="name",value=newname)
+        self._parse_lastvalue()
+
+    def __repr__(self) -> str:
+        return f"<Channel name={self.name!r} id={self.id}>"
+
+    def _parse_lastvalue(self) -> None:
+        if not hasattr(self, "lastvalue") or not self.lastvalue:
+            return
+        parts = self.lastvalue.split(" ", 1)
+        try:
+            self.lastvalue_float = float(parts[0].replace(",", ""))
+            self.lastvalue_int = int(self.lastvalue_float)
+            self.unit = parts[1] if len(parts) > 1 else ""
+        except ValueError:
+            # Non-numeric lastvalue (e.g. "OK", "-") — leave fields unset.
+            pass
+
+    def rename(self, newname: str) -> None:
+        self.set_property(name="name", value=newname)
         self.name = newname
-    def pause(self,duration=0,message=""):
-        print("Channels cannot be paused, pausing parent sensor.")
+
+    def pause(self, duration: int = 0, message: str = "") -> None:
+        log.warning(
+            "Channels cannot be paused directly; pausing parent sensor %s",
+            self.sensorid,
+        )
         if duration > 0:
-            pause_url = "pauseobjectfor.htm?id={objid}&duration={time}".format(objid=self.sensorid,time=duration)
+            path = "pauseobjectfor.htm"
+            params: dict[str, Any] = {
+                "id": self.sensorid,
+                "duration": duration,
+            }
         else:
-            pause_url = "pause.htm?id={objid}&action=0&".format(objid=self.sensorid)
+            path = "pause.htm"
+            params = {"id": self.sensorid, "action": 0}
         if message:
-            pause_url += "&pausemsg={string}".format(string=message)
-        req = self.get_request(url_string=pause_url)
-    def resume(self):
-        print("Channels cannot be resumed, resuming parent sensor.")
-        resume_url = "pause.htm?id={objid}&action=1".format(objid=self.sensorid)
-        req = self.get_request(url_string=resume_url)
-    def refresh(self,channelsoup):
-        for child in channelsoup.children:
-            if child.string is None:
-                child.string = ""
-            if child.name is not None:
-                setattr(self,child.name,child.string)
+            params["pausemsg"] = message
+        self.get_request(path, params=params)
+
+    def resume(self) -> None:
+        log.warning(
+            "Channels cannot be resumed directly; resuming parent sensor %s",
+            self.sensorid,
+        )
+        self.get_request(
+            "pause.htm",
+            params={"id": self.sensorid, "action": 1},
+        )
+
+    def refresh(self, channelsoup) -> None:
+        _absorb_simple_children(self, channelsoup)
         self.id = self.objid
-    def delete(self):
-        return("You cannot delete a channel")
+        self._parse_lastvalue()
+
+    def delete(self, confirm: bool = True) -> None:
+        raise PrtgError("Channels cannot be deleted.")
 
 
-class sensor(prtg_api):
-    def __init__(self,sensorsoup,deviceid,confdata):
+# ---------------------------------------------------------------------------
+# Sensor
+# ---------------------------------------------------------------------------
+
+
+class Sensor(BaseConfig, GlobalArrays):
+    type = "Sensor"
+
+    def __init__(self, sensorsoup, deviceid: str, confdata: ConfData) -> None:
         self.unpack_config(confdata)
-        for child in sensorsoup.children:
-            if child.string is None:
-                child.string = ""
-            if child.name is not None:
-                setattr(self,child.name,child.string)
-        setattr(self,"attributes",sensorsoup.attrs)
-        self.channels = []
-        self.type = "Sensor"
+        _absorb_simple_children(self, sensorsoup)
+        self.attributes = sensorsoup.attrs
+        self.channels: list[Channel] = []
         self.deviceid = deviceid
-    def get_channels(self):
-        channel_url = "table.xml?content=channels&output=xml&columns=name,lastvalue_,objid&id={sensorid}".format(sensorid=self.id)
-        req = self.get_request(url_string=channel_url)
-        channelsoup = BeautifulSoup(req.text,"lxml")
-        if len(self.channels) == 0:
-            for child in channelsoup.find_all("item"):
-                self.channels.append(channel(child,self.id,self.confdata))
-        else:
-            for child in channelsoup.find_all("item"):
-                for achannel in self.channels:
-                    if achannel.objid == child.find("objid").string:
-                        achannel.refresh(child)
-    def refresh(self,sensorsoup=None):
+
+    def get_channels(self) -> None:
+        req = self.get_request(
+            "table.xml",
+            params={
+                "content": "channels",
+                "output": "xml",
+                "columns": "name,lastvalue_,objid",
+                "id": self.id,
+            },
+        )
+        channelsoup = BeautifulSoup(req.text, "xml")
+
+        if not self.channels:
+            for item in channelsoup.find_all("item"):
+                self.channels.append(Channel(item, self.id, self.confdata))
+            return
+
+        # Refresh existing channels in-place where possible.
+        by_objid = {c.objid: c for c in self.channels}
+        for item in channelsoup.find_all("item"):
+            objid = item.find("objid").string
+            existing = by_objid.get(objid)
+            if existing is not None:
+                existing.refresh(item)
+
+    def refresh(self, sensorsoup=None) -> None:
         if sensorsoup is None:
             soup = self.get_tree(root=self.id)
             sensorsoup = soup.sensortree.nodes.sensor
-        for child in sensorsoup.children:
-            if child.string is None:
-                child.string = ""
-            if child.name is not None:
-                setattr(self,child.name,child.string)
-        setattr(self,"attributes",sensorsoup.attrs)
-        if len(self.channels) > 0:
+        _absorb_simple_children(self, sensorsoup)
+        self.attributes = sensorsoup.attrs
+        if self.channels:
             self.get_channels()
-    def set_additional_param(self,parameterstring):
-        self.set_property(name="params",value=parameterstring)
-    def acknowledge(self,message=""):
-        acknowledge_url = "acknowledgealarm.htm?id={objid}&ackmsg={string}".format(objid=self.id,string=message)
-        req = self.get_request(url_string=acknowledge_url)
+
+    def set_additional_param(self, parameterstring: str) -> None:
+        self.set_property(name="params", value=parameterstring)
+
+    def acknowledge(self, message: str = "") -> None:
+        """Acknowledge an alarm, then refresh status to reflect the change."""
+        super().acknowledge(message)
         self.get_status()
-    def save_graph(self,graphid,filepath,size,hidden_channels='',filetype='svg'):
-        '''
-        Size options: S,M,L
-        '''
-        if size.upper() == "L":
-            width = "1500"
-            height = "500"
-            font = "13"
-        elif size.upper() == "S":
-            width = "400"
-            height = "300"
-            font = "9"
-        else:
-            width = "800"
-            height = "350"
-            font = "13"
-        if hidden_channels:
-            hidden_channels = "&hide={hc}".format(hc=hidden_channels)
-        chart_url = "chart.{ft}?type=graph&graphid={gid}&id={sid}&width={w}&height={h}{hc}&plotcolor=%23ffffff&gridcolor=%23ffffff&graphstyling=showLegend%3D%271%27+baseFontSize%3D%27{f}%27".format(
-            ft=filetype,gid=graphid,sid=self.id,w=width,h=height,hc=hidden_channels,f=font)
-        req = self.get_request(url_string=chart_url,api=False)
-        with open(filepath,"wb") as imgfile:
-            for chunk in req:
-                imgfile.write(chunk)
-        self.filepath = filepath
-    def get_details(self):
-        details_url = "getsensordetails.json?id={id}".format(id=self.id)
-        req = self.get_request(url_string=details_url)
-        self.details = json.loads(req.text)['sensordata']
 
 
-class device(prtg_api):
-    def __init__(self,devicesoup,confdata):
+# ---------------------------------------------------------------------------
+# Device
+# ---------------------------------------------------------------------------
+
+
+class Device(BaseConfig, GlobalArrays):
+    type = "Device"
+
+    def __init__(self, devicesoup, confdata: ConfData) -> None:
         self.unpack_config(confdata)
-        self.sensors = []
-        for child in devicesoup.children:
+        self.sensors: list[Sensor] = []
+        for child in _iter_named_children(devicesoup):
             if child.name == "sensor":
-                sensorobj = sensor(child,self.id,self.confdata)
-                self.sensors.append(sensorobj)
-                self.allsensors.append(sensorobj)
-            elif child.name is not None:
+                sensor = Sensor(child, devicesoup.find("id").string, self.confdata)
+                self.sensors.append(sensor)
+                self.allsensors.append(sensor)
+            else:
                 if child.string is None:
                     child.string = ""
-                setattr(self,child.name,child.string)
-        #Adds sensors to a dictionary based on their status
-        self.sensors_by_status = {"Up":[],"Down":[],"Warning":[],"Paused":[]}
-        for asensor in self.sensors:
-            if asensor.status in self.sensors_by_status.keys():
-                self.sensors_by_status[asensor.status].append(asensor)
-            else:
-                self.sensors_by_status[asensor.status] = [asensor]
-        setattr(self,"attributes",devicesoup.attrs)
-        self.type = "Device"
-    def refresh(self,devicesoup=None):
+                setattr(self, child.name, child.string)
+
+        self._build_sensors_by_status()
+        self.attributes = devicesoup.attrs
+
+    def _build_sensors_by_status(self) -> None:
+        self.sensors_by_status: dict[str, list[Sensor]] = {
+            "Up": [],
+            "Down": [],
+            "Warning": [],
+            "Paused": [],
+        }
+        for sensor in self.sensors:
+            self.sensors_by_status.setdefault(sensor.status, []).append(sensor)
+
+    def refresh(self, devicesoup=None) -> None:
         if devicesoup is None:
             soup = self.get_tree(root=self.id)
             devicesoup = soup.sensortree.nodes.device
-        sensorids = []
-        newsensorids = []
-        for asensor in self.sensors:
-            sensorids.append(asensor.id)
-        for child in devicesoup.children:
-            if child.name == "sensor":
-                if child.find("id").string in sensorids:
-                    for asensor in self.sensors:
-                        if asensor.id == child.find("id").string:
-                            asensor.refresh(child)
-                else:
-                    sensorobj = sensor(child,self.id,self.confdata)
-                    self.sensors.append(sensorobj)
-                    self.allsensors.append(sensorobj)
-                newsensorids.append(child.find("id").string)
-            elif child.name is not None:
+
+        sensor_soups = [c for c in _iter_named_children(devicesoup) if c.name == "sensor"]
+        _reconcile_children(
+            sensor_soups,
+            self.sensors,
+            lambda s: Sensor(s, self.id, self.confdata),
+            self.allsensors,
+        )
+
+        # Refresh non-child fields
+        for child in _iter_named_children(devicesoup):
+            if child.name != "sensor":
                 if child.string is None:
                     child.string = ""
-                setattr(self,child.name,child.string)
-        for id in sensorids:
-            if id not in newsensorids:
-                for asensor in self.sensors:
-                    if asensor.id == id:
-                        sensortoremove = asensor
-                self.sensors.remove(sensortoremove)
-                self.allsensors.remove(sensortoremove)
-        setattr(self,"attributes",devicesoup.attrs)
-    def set_host(self,host):
-        self.set_property(name="host",value=host)
+                setattr(self, child.name, child.string)
+
+        self.attributes = devicesoup.attrs
+        self._build_sensors_by_status()
+
+    def set_host(self, host: str) -> None:
+        self.set_property(name="host", value=host)
         self.host = host
 
 
-class group(prtg_api):
-    def __init__(self,groupsoup,confdata):
+# ---------------------------------------------------------------------------
+# Group / Probe
+# ---------------------------------------------------------------------------
+
+
+class Group(BaseConfig, GlobalArrays):
+    type = "Group"
+
+    def __init__(self, groupsoup, confdata: ConfData) -> None:
         self.unpack_config(confdata)
-        self.groups = []
-        self.devices = []
-        #groupsoup is passed into __init__ method
-        #The children objects are either added to this object as an attribute
-        #or a device/group object is created
-        for child in groupsoup.children:
+        self.groups: list[Group] = []
+        self.devices: list[Device] = []
+        for child in _iter_named_children(groupsoup):
             if child.name == "device":
-                deviceobj = device(child,self.confdata)
-                self.devices.append(deviceobj)
-                self.alldevices.append(deviceobj)
+                d = Device(child, self.confdata)
+                self.devices.append(d)
+                self.alldevices.append(d)
             elif child.name == "group":
-                groupobj = group(child,self.confdata)
-                self.groups.append(groupobj)
-                self.allgroups.append(groupobj)             
-            elif child.name is not None:
+                g = Group(child, self.confdata)
+                self.groups.append(g)
+                self.allgroups.append(g)
+            else:
                 if child.string is None:
                     child.string = ""
-                setattr(self,child.name,child.string)
-        setattr(self,"attributes",groupsoup.attrs)
-        self.type = "Group"
-    def refresh(self,groupsoup=None):
+                setattr(self, child.name, child.string)
+        self.attributes = groupsoup.attrs
+
+    def refresh(self, groupsoup=None) -> None:
         if groupsoup is None:
-            if self.type == "Group":
-                soup = self.get_tree(root=self.id)
-                groupsoup = soup.sensortree.nodes.group
-            elif self.type == "Probe":
-                soup = self.get_tree(root=self.id)
-                groupsoup = soup.sensortree.nodes.probenode
-        deviceids = []
-        newdeviceids = []
-        for adevice in self.devices:
-            deviceids.append(adevice.id)
-        groupids = []
-        newgroupids = []
-        for agroup in self.groups:
-            groupids.append(agroup.id)
-        for child in groupsoup.children:
-            if child.name == "device":
-                if child.find("id").string in deviceids:
-                    for adevice in self.devices:
-                        if adevice.id == child.find("id").string:
-                            adevice.refresh(child)
-                else:
-                    deviceobj = device(child,self.confdata)
-                    self.devices.append(deviceobj)
-                    self.alldevices.append(deviceobj)
-                newdeviceids.append(child.find("id").string)
-            elif child.name == "group":
-                if child.find("id").string in groupids:
-                    for agroup in self.groups:
-                        if agroup.id == child.find("id").string:
-                            agroup.refresh(child)
-                else:
-                    groupobj = group(child,self.confdata)
-                    self.groups.append(groupobj)
-                    self.allgroups.append(groupobj)
-                newgroupids.append(child.find("id").string)
-            elif child.name is not None:
+            soup = self.get_tree(root=self.id)
+            root_node = soup.sensortree.nodes
+            groupsoup = root_node.probenode if self.type == "Probe" else root_node.group
+
+        device_soups = [c for c in _iter_named_children(groupsoup) if c.name == "device"]
+        group_soups = [c for c in _iter_named_children(groupsoup) if c.name == "group"]
+
+        _reconcile_children(
+            device_soups,
+            self.devices,
+            lambda s: Device(s, self.confdata),
+            self.alldevices,
+        )
+        _reconcile_children(
+            group_soups,
+            self.groups,
+            lambda s: Group(s, self.confdata),
+            self.allgroups,
+        )
+
+        # Refresh non-child fields
+        for child in _iter_named_children(groupsoup):
+            if child.name not in ("device", "group"):
                 if child.string is None:
                     child.string = ""
-                setattr(self,child.name,child.string)
-        for id in deviceids:
-            if id not in newdeviceids:
-                for adevice in self.devices:
-                    if adevice.id == id:
-                        devicetoremove = adevice
-                self.devices.remove(devicetoremove)
-                self.alldevices.remove(devicetoremove)
-        for id in groupids:
-            if id not in newgroupids:
-                for agroup in self.groups:
-                    if agroup.id == id:
-                        grouptoremove = agroup
-                self.groups.remove(grouptoremove)
-                self.allgroups.remove(grouptoremove)
-        setattr(self,"attributes",groupsoup.attrs)
+                setattr(self, child.name, child.string)
+
+        self.attributes = groupsoup.attrs
 
 
-#probe is the same as group so it inherits all methods and attributes except type               
-class probe(group):     
+class Probe(Group):
+    """A Probe is structurally identical to a Group; only the type differs."""
+
     type = "Probe"
 
 
-class prtg_device(baseconfig):
-    '''Seperate top level object to manage just a device and its sensors instead of
-    downloading details for an entire group'''
-    def __init__(self,host,user=None,passhash=None,apikey=None,deviceid=0,protocol='https',port='443'):
-        self.confdata = (host,port,user,passhash,protocol,apikey)
-        self.unpack_config(self.confdata)
-        self.sensors = []
-        soup = self.get_tree(root=deviceid)
-        for child in soup.sensortree.nodes.device:
-            if child.name == "sensor":
-                sensorobj = sensor(child,self.id,self.confdata)
-                self.sensors.append(sensorobj)
-            elif child.name is not None:
-                if child.string is None:
-                    child.string = ""
-                setattr(self,child.name,child.string)
-        self.sensors_by_status = {"Up":[],"Down":[],"Warning":[],"Paused":[]}
-        for asensor in self.sensors:
-            if asensor.status in self.sensors_by_status.keys():
-                self.sensors_by_status[asensor.status].append(asensor)
-            else:
-                self.sensors_by_status[asensor.status] = [asensor]
-    def refresh(self):
-        soup = self.get_tree(root=deviceid)
-        sensorids = []
-        for asensor in self.sensors:
-            sensorids.append(asensor.id)
-        for child in soup.sensortree.nodes.device:
-            if child.name == "sensor":
-                if child.find("id").string in sensorids:
-                    for asensor in self.sensors:
-                        if asensor.id == child.find("id").string:
-                            asensor.refresh(child)
+# ---------------------------------------------------------------------------
+# Top-level entry points
+# ---------------------------------------------------------------------------
+
+
+class PrtgApi(BaseConfig, GlobalArrays):
+    """
+    Top-level entry point for managing a PRTG server.
+
+    Parameters:
+        host:       PRTG server hostname or IP.
+        user:       PRTG username (omit when using apikey).
+        passhash:   PRTG passhash from Settings > Account Settings.
+        apikey:     PRTG API token (preferred over user/passhash).
+        rootid:     Root id of the subtree to manage. 0 = entire tree.
+        protocol:   'http' or 'https'.
+        port:       TCP port as a string, e.g. '443'.
+        verify_ssl: Whether to verify TLS certificates. Default False
+                    (matches the original module's behaviour). Set True
+                    to enable certificate verification.
+        timeout:    Per-request timeout in seconds. Default 30.
+
+    Example:
+        prtg = PrtgApi(
+            host="192.168.1.1",
+            user="prtgadmin",
+            passhash="0000000",
+            rootid=53,
+        )
+    """
+
+    def __init__(
+        self,
+        host: str,
+        user: str | None = None,
+        passhash: str | None = None,
+        apikey: str | None = None,
+        rootid: str | int = 0,
+        protocol: str = "https",
+        port: str = "443",
+        verify_ssl: bool = False,
+        timeout: float = 30.0,
+    ) -> None:
+        confdata = ConfData(host, port, user, passhash, protocol, apikey, verify_ssl, timeout)
+        self.unpack_config(confdata)
+        self.clear_arrays()
+
+        self.probes: list[Probe] = []
+        self.groups: list[Group] = []
+        self.devices: list[Device] = []
+
+        self.treesoup = self.get_tree(root=rootid)
+        self._parse_tree(self.treesoup.sensortree.nodes)
+
+    def _parse_tree(self, nodes_soup) -> None:
+        """Walk the top-level <nodes> element and create child objects."""
+        for parent in _iter_named_children(nodes_soup):
+            for child in _iter_named_children(parent):
+                if child.name == "probenode":
+                    p = Probe(child, self.confdata)
+                    self.probes.append(p)
+                    self.allprobes.append(p)
+                elif child.name == "device":
+                    d = Device(child, self.confdata)
+                    self.devices.append(d)
+                    self.alldevices.append(d)
+                elif child.name == "group":
+                    g = Group(child, self.confdata)
+                    self.groups.append(g)
+                    self.allgroups.append(g)
                 else:
-                    sensorobj = sensor(child,self.id,self.confdata)
-                    self.sensors.append(sensorobj)
-            elif child.name is not None:
-                if child.string is None:
-                    child.string = ""
-                setattr(self,child.name,child.string)
+                    if child.string is None:
+                        child.string = ""
+                    setattr(self, child.name, child.string)
 
+    def refresh(self) -> None:
+        """Re-download the sensortree and reconcile in-memory objects."""
+        self.treesoup = self.get_tree(root=self.id)
 
-class prtg_sensor(baseconfig):
-    '''Seperate top level object to manage just a sensor and its channels instead of
-    downloading details for an entire group'''
-    def __init__(self,host,user=None,passhash=None,apikey=None,sensorid=0,protocol='https',port='443'):
-        self.confdata = (host,port,user,passhash,protocol,apikey)
-        self.unpack_config(self.confdata)
-        self.channels = []
-        soup = self.get_tree(root=sensorid)
-        for child in soup.sensortree.nodes.sensor:
-            if child.name is not None:
-                if child.string is None:
-                    child.string = ""
-                setattr(self,child.name,child.string)
-        self.get_channels()
-    def refresh(self):
-        soup = self.get_tree(root=self.id)
-        for child in soup.sensortree.nodes.sensor.children:
+        # Collect direct candidates from the tree
+        probe_soups: list = []
+        group_soups: list = []
+        device_soups: list = []
+        leftover: list = []
+        for parent in _iter_named_children(self.treesoup.sensortree.nodes):
+            for child in _iter_named_children(parent):
+                if child.name == "probenode":
+                    probe_soups.append(child)
+                elif child.name == "group":
+                    group_soups.append(child)
+                elif child.name == "device":
+                    device_soups.append(child)
+                else:
+                    leftover.append(child)
+
+        _reconcile_children(
+            probe_soups,
+            self.probes,
+            lambda s: Probe(s, self.confdata),
+            self.allprobes,
+        )
+        _reconcile_children(
+            group_soups,
+            self.groups,
+            lambda s: Group(s, self.confdata),
+            self.allgroups,
+        )
+        _reconcile_children(
+            device_soups,
+            self.devices,
+            lambda s: Device(s, self.confdata),
+            self.alldevices,
+        )
+
+        for child in leftover:
             if child.string is None:
                 child.string = ""
-            if child.name is not None:
-                setattr(self,child.name,child.string)
-        setattr(self,"attributes",sensorsoup.attrs)
-        self.get_channels()
-    def get_channels(self):
-        channel_url = "table.xml?content=channels&output=xml&columns=name,lastvalue_,objid&id={sensorid}".format(sensorid=self.id)
-        req = self.get_request(url_string=channel_url)
-        channelsoup = BeautifulSoup(req.text,"lxml")
-        if len(self.channels) == 0:
-            for child in channelsoup.find_all("item"):
-                self.channels.append(channel(child,self.id,self.confdata))
-        else:
-            for child in channelsoup.find_all("item"):
-                for achannel in self.channels:
-                    if achannel.objid == child.find("objid").string:
-                        achannel.refresh(child)
-    def acknowledge(self,message=""):
-        acknowledge_url = "acknowledgealarm.htm?id={objid}&ackmsg={string}".format(objid=self.id,string=message)
-        req = self.get_request(url_string=acknowledge_url)
-    def save_graph(self,graphid,filepath,size,hidden_channels='',filetype='svg'):
-        '''
-        Size options: S,M,L
-        '''
-        if size.upper() == "L":
-            width = "1500"
-            height = "500"
-            font = "13"
-        elif size.upper() == "S":
-            width = "400"
-            height = "300"
-            font = "9"
-        else:
-            width = "800"
-            height = "350"
-            font = "13"
-        if hidden_channels:
-            hidden_channels = "&hide={hc}".format(hc=hidden_channels)
-        chart_url = "chart.{ft}?type=graph&graphid={gid}&id={sid}&width={w}&height={h}{hc}&plotcolor=%23ffffff&gridcolor=%23ffffff&graphstyling=showLegend%3D%271%27+baseFontSize%3D%27{f}%27".format(
-            ft=filetype,gid=graphid,sid=self.id,w=width,h=height,hc=hidden_channels,f=font)
-        req = self.get_request(url_string=chart_url,api=False)
-        with open(filepath,"wb") as imgfile:
-            for chunk in req:
-                imgfile.write(chunk)
-        self.filepath = filepath
-    def get_details(self):
-        details_url = "getsensordetails.json?id={id}".format(id=self.id)
-        req = self.get_request(url_string=details_url)
-        self.details = json.loads(req.text)['sensordata']
+            setattr(self, child.name, child.string)
+
+    def search_byid(self, oid: str | int):
+        """Find any object in the tree by id; returns None if not found."""
+        oid = str(oid)
+        for obj in (
+            self.allprobes + self.allgroups + self.alldevices + self.allsensors
+        ):
+            if obj.id == oid:
+                return obj
+        return None
 
 
-class prtg_historic_data(connection_methods):
-    '''class used for calls to the historic data api.
-    Call the class first using connection params then use
-    methods to get/process data. yyyy-mm-dd-hh-mm-ss'''
-    def __init__(self,host,user=None,passhash=None,apikey=None,port='443',protocol='https'):
-        self.confdata = (host,port,user,passhash,protocol,apikey)
-        self.unpack_config(self.confdata)
-    def format_date(self,dateobj):
-        '''Pass a datetime object and this will format appropriately
-        for use with the historic data api'''
-        return(dateobj.strftime("%Y-%m-%d-%H-%M-%S"))
-    def get_historic_data(self,objid,startdate,enddate,timeaverage):
-        if type(startdate) == datetime:
-            startdate = self.format_date(startdate)
-        if type(enddate) == datetime:
-            enddate = self.format_date(enddate) 
-        historic_url = "historicdata.csv?id={id}&avg={avg}&sdate={sdate}&edate={edate}".format(id=objid,avg=timeaverage,sdate=startdate,edate=enddate)
-        req = self.get_request(url_string=historic_url)
-        csvRaw = req.text
-        csvLines = (csvRaw.split("\n"))[:-2]
-        csvReader = csv.reader(csvLines)
-        data = {}
-        for ind,row in enumerate(csvReader):
-            if ind == 0:
-                headers = row
-                for header in headers:
-                    data[header] = []
+class PrtgDevice(BaseConfig):
+    """
+    Separate top-level entry point to manage a single device and its sensors
+    without downloading an entire group tree.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        user: str | None = None,
+        passhash: str | None = None,
+        apikey: str | None = None,
+        deviceid: str | int = 0,
+        protocol: str = "https",
+        port: str = "443",
+        verify_ssl: bool = False,
+        timeout: float = 30.0,
+    ) -> None:
+        confdata = ConfData(host, port, user, passhash, protocol, apikey, verify_ssl, timeout)
+        self.unpack_config(confdata)
+        self.deviceid = str(deviceid)
+        self.sensors: list[Sensor] = []
+        self._load()
+
+    def _load(self) -> None:
+        soup = self.get_tree(root=self.deviceid)
+        device_node = soup.sensortree.nodes.device
+        for child in _iter_named_children(device_node):
+            if child.name == "sensor":
+                self.sensors.append(
+                    Sensor(child, device_node.find("id").string, self.confdata)
+                )
             else:
-                for inde,cell in enumerate(row):
-                    if headers[inde] == "Date Time":
-                        if "-" in cell:
-                            cell = cell[:cell.index(" -")]
-                        data[headers[inde]].append(datetime.strptime(cell,"%m/%d/%Y %I:%M:%S %p"))
-                    else:
-                        data[headers[inde]].append(cell)
-        return(data)
+                if child.string is None:
+                    child.string = ""
+                setattr(self, child.name, child.string)
+
+        self.sensors_by_status: dict[str, list[Sensor]] = {
+            "Up": [],
+            "Down": [],
+            "Warning": [],
+            "Paused": [],
+        }
+        for sensor in self.sensors:
+            self.sensors_by_status.setdefault(sensor.status, []).append(sensor)
+
+    def refresh(self) -> None:
+        soup = self.get_tree(root=self.deviceid)
+        device_node = soup.sensortree.nodes.device
+        sensor_soups = [
+            c for c in _iter_named_children(device_node) if c.name == "sensor"
+        ]
+        _reconcile_children(
+            sensor_soups,
+            self.sensors,
+            lambda s: Sensor(s, self.id, self.confdata),
+        )
+        for child in _iter_named_children(device_node):
+            if child.name != "sensor":
+                if child.string is None:
+                    child.string = ""
+                setattr(self, child.name, child.string)
+
+
+class PrtgSensor(BaseConfig):
+    """
+    Separate top-level entry point to manage a single sensor and its channels
+    without downloading an entire group tree.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        user: str | None = None,
+        passhash: str | None = None,
+        apikey: str | None = None,
+        sensorid: str | int = 0,
+        protocol: str = "https",
+        port: str = "443",
+        verify_ssl: bool = False,
+        timeout: float = 30.0,
+    ) -> None:
+        confdata = ConfData(host, port, user, passhash, protocol, apikey, verify_ssl, timeout)
+        self.unpack_config(confdata)
+        self.sensorid = str(sensorid)
+        self.channels: list[Channel] = []
+
+        soup = self.get_tree(root=self.sensorid)
+        sensor_node = soup.sensortree.nodes.sensor
+        _absorb_simple_children(self, sensor_node)
+        self.attributes = sensor_node.attrs
+        self.get_channels()
+
+    def refresh(self) -> None:
+        soup = self.get_tree(root=self.id)
+        sensor_node = soup.sensortree.nodes.sensor
+        _absorb_simple_children(self, sensor_node)
+        self.attributes = sensor_node.attrs
+        self.get_channels()
+
+    def get_channels(self) -> None:
+        req = self.get_request(
+            "table.xml",
+            params={
+                "content": "channels",
+                "output": "xml",
+                "columns": "name,lastvalue_,objid",
+                "id": self.id,
+            },
+        )
+        channelsoup = BeautifulSoup(req.text, "xml")
+
+        if not self.channels:
+            for item in channelsoup.find_all("item"):
+                self.channels.append(Channel(item, self.id, self.confdata))
+            return
+
+        by_objid = {c.objid: c for c in self.channels}
+        for item in channelsoup.find_all("item"):
+            objid = item.find("objid").string
+            existing = by_objid.get(objid)
+            if existing is not None:
+                existing.refresh(item)
+
+
+# ---------------------------------------------------------------------------
+# Historic data (deprecated standalone client)
+# ---------------------------------------------------------------------------
+
+
+class PrtgHistoricData(ConnectionMethods):
+    """
+    Deprecated. Use ``sensor.get_historic_data(...)`` directly on any
+    Sensor / PrtgSensor object instead.
+
+    Kept as a thin shim for backwards compatibility. Emits
+    ``DeprecationWarning`` on construction.
+
+    Old usage:
+        h = PrtgHistoricData(host=..., apikey=...)
+        data = h.get_historic_data(objid=1234, startdate=..., enddate=..., timeaverage=300)
+
+    New usage:
+        sensor = PrtgSensor(host=..., apikey=..., sensorid=1234)
+        data = sensor.get_historic_data(startdate=..., enddate=..., timeaverage=300)
+
+    Or on a Sensor already loaded via PrtgApi:
+        data = api.search_byid(1234).get_historic_data(...)
+    """
+
+    def __init__(
+        self,
+        host: str,
+        user: str | None = None,
+        passhash: str | None = None,
+        apikey: str | None = None,
+        port: str = "443",
+        protocol: str = "https",
+        verify_ssl: bool = False,
+        timeout: float = 30.0,
+    ) -> None:
+        import warnings as _warnings
+        _warnings.warn(
+            "PrtgHistoricData is deprecated; call get_historic_data() "
+            "directly on a Sensor or PrtgSensor object instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        confdata = ConfData(
+            host, port, user, passhash, protocol, apikey, verify_ssl, timeout
+        )
+        self.unpack_config(confdata)
+
+    @staticmethod
+    def format_date(dateobj: datetime) -> str:
+        """Format a datetime in the form PRTG expects: YYYY-MM-DD-HH-MM-SS."""
+        return _format_prtg_date(dateobj)
+
+    def get_historic_data(
+        self,
+        objid: str | int,
+        startdate: datetime | str,
+        enddate: datetime | str,
+        timeaverage: int,
+    ) -> dict[str, list]:
+        """Fetch historic data for an arbitrary object id."""
+        if isinstance(startdate, datetime):
+            startdate = _format_prtg_date(startdate)
+        if isinstance(enddate, datetime):
+            enddate = _format_prtg_date(enddate)
+
+        req = self.get_request(
+            "historicdata.csv",
+            params={
+                "id": objid,
+                "avg": timeaverage,
+                "sdate": startdate,
+                "edate": enddate,
+            },
+        )
+        return _parse_historic_csv(req.text)
+
+
+# ---------------------------------------------------------------------------
+# Deprecated lowercase aliases
+# ---------------------------------------------------------------------------
+#
+# The original module used PEP-8-non-conforming class names (`prtg_api`,
+# `prtg_device`, `prtg_sensor`). These aliases let existing scripts keep
+# working as drop-in replacements while emitting a DeprecationWarning that
+# acts as a TODO marker. Update your imports to the PascalCase names at
+# your convenience; the aliases will be removed in a future release.
+
+
+def _make_deprecated_alias(new_cls: type, old_name: str) -> type:
+    """Build a subclass of ``new_cls`` that warns on construction."""
+
+    class _Deprecated(new_cls):  # type: ignore[valid-type, misc]
+        def __init__(self, *args, **kwargs):
+            import warnings as _warnings
+            _warnings.warn(
+                f"{old_name} is deprecated; use {new_cls.__name__} instead. "
+                f"They are identical, only the class name has changed.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            super().__init__(*args, **kwargs)
+
+    _Deprecated.__name__ = old_name
+    _Deprecated.__qualname__ = old_name
+    _Deprecated.__doc__ = (
+        f"Deprecated alias for {new_cls.__name__}. "
+        f"Will be removed in a future release."
+    )
+    return _Deprecated
+
+
+prtg_api = _make_deprecated_alias(PrtgApi, "prtg_api")
+prtg_device = _make_deprecated_alias(PrtgDevice, "prtg_device")
+prtg_sensor = _make_deprecated_alias(PrtgSensor, "prtg_sensor")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests>=2.25
+beautifulsoup4>=4.9
+lxml>=4.6
+urllib3>=1.26

--- a/tests/test_prtg.py
+++ b/tests/test_prtg.py
@@ -1,0 +1,1022 @@
+"""
+Tests for prtg.py.
+
+The HTTP layer is mocked end-to-end — no real PRTG server is required.
+Tests cover:
+
+  * URL/parameter construction (the biggest correctness change in the
+    refactor — values are now sent via ``params=`` and must be properly
+    encoded).
+  * Parsing the sensortree XML into nested Python objects.
+  * refresh() reconciliation: existing objects updated, new ones added,
+    missing ones removed, across PrtgApi, Group, Device.
+  * The historic-data CSV parser.
+  * The clone() id-extraction logic, including the login-page response
+    shape that was producing AttributeError on `req.history[-1]` in the
+    original code.
+
+Run with:
+    python -m unittest discover tests
+or:
+    python -m pytest tests/
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+import prtg
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_response(
+    text: str = "",
+    status_code: int = 200,
+    url: str = "https://prtg.example.com/api/foo",
+    history_urls: list[str] | None = None,
+) -> MagicMock:
+    """Build a mock requests.Response with the bits prtg.py inspects."""
+    resp = MagicMock()
+    resp.text = text
+    resp.status_code = status_code
+    resp.url = url
+    resp.history = []
+    if history_urls:
+        for hurl in history_urls:
+            h = MagicMock()
+            h.url = hurl
+            resp.history.append(h)
+    # For save_graph streaming
+    resp.iter_content = lambda chunk_size=None: iter([b""])
+    resp.raise_for_status = lambda: None
+    return resp
+
+
+SENSORTREE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<sensortree>
+  <nodes>
+    <group>
+      <id>0</id>
+      <name>Root</name>
+      <active>true</active>
+      <probenode>
+        <id>1</id>
+        <name>Local Probe</name>
+        <active>true</active>
+        <group>
+          <id>10</id>
+          <name>Servers</name>
+          <active>true</active>
+          <device>
+            <id>100</id>
+            <name>web-01</name>
+            <active>true</active>
+            <host>10.0.0.1</host>
+            <sensor>
+              <id>1000</id>
+              <name>Ping</name>
+              <active>true</active>
+              <status>Up</status>
+            </sensor>
+            <sensor>
+              <id>1001</id>
+              <name>HTTP</name>
+              <active>true</active>
+              <status>Warning</status>
+            </sensor>
+          </device>
+          <device>
+            <id>101</id>
+            <name>db-01</name>
+            <active>true</active>
+            <host>10.0.0.2</host>
+          </device>
+        </group>
+      </probenode>
+    </group>
+  </nodes>
+</sensortree>
+"""
+
+
+# Same tree but with web-01's HTTP sensor removed and a new sensor added,
+# plus the db-01 device removed entirely.
+SENSORTREE_XML_AFTER_CHANGES = """<?xml version="1.0" encoding="UTF-8"?>
+<sensortree>
+  <nodes>
+    <group>
+      <id>0</id>
+      <name>Root</name>
+      <active>true</active>
+      <probenode>
+        <id>1</id>
+        <name>Local Probe</name>
+        <active>true</active>
+        <group>
+          <id>10</id>
+          <name>Servers</name>
+          <active>true</active>
+          <device>
+            <id>100</id>
+            <name>web-01</name>
+            <active>true</active>
+            <host>10.0.0.1</host>
+            <sensor>
+              <id>1000</id>
+              <name>Ping</name>
+              <active>true</active>
+              <status>Up</status>
+            </sensor>
+            <sensor>
+              <id>1002</id>
+              <name>CPU</name>
+              <active>true</active>
+              <status>Up</status>
+            </sensor>
+          </device>
+        </group>
+      </probenode>
+    </group>
+  </nodes>
+</sensortree>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Construction & parsing
+# ---------------------------------------------------------------------------
+
+
+class TestPrtgApiConstruction(unittest.TestCase):
+    """Verify the sensortree XML is parsed into nested objects correctly."""
+
+    def setUp(self) -> None:
+        prtg.GlobalArrays.allprobes.clear()
+        prtg.GlobalArrays.allgroups.clear()
+        prtg.GlobalArrays.alldevices.clear()
+        prtg.GlobalArrays.allsensors.clear()
+
+    @patch("prtg.requests.get")
+    def test_constructs_tree(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(
+            host="prtg.example.com",
+            apikey="testtoken",
+            rootid=0,
+        )
+        self.assertEqual(len(api.probes), 1)
+        probe = api.probes[0]
+        self.assertEqual(probe.id, "1")
+        self.assertEqual(probe.name, "Local Probe")
+        self.assertEqual(probe.type, "Probe")
+        self.assertEqual(len(probe.groups), 1)
+        group = probe.groups[0]
+        self.assertEqual(group.name, "Servers")
+        self.assertEqual(len(group.devices), 2)
+        web = next(d for d in group.devices if d.name == "web-01")
+        self.assertEqual(web.host, "10.0.0.1")
+        self.assertEqual(len(web.sensors), 2)
+
+    @patch("prtg.requests.get")
+    def test_global_arrays_populated(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        self.assertEqual(len(api.allprobes), 1)
+        self.assertEqual(len(api.allgroups), 1)
+        self.assertEqual(len(api.alldevices), 2)
+        self.assertEqual(len(api.allsensors), 2)
+
+    @patch("prtg.requests.get")
+    def test_search_byid(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        self.assertEqual(api.search_byid(100).name, "web-01")
+        self.assertEqual(api.search_byid("1001").name, "HTTP")
+        self.assertIsNone(api.search_byid(99999))
+
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+
+
+class TestAuth(unittest.TestCase):
+    def test_no_credentials_raises(self):
+        with self.assertRaises(prtg.AuthenticationError):
+            prtg.PrtgApi(host="x")
+
+    def test_partial_credentials_raises(self):
+        with self.assertRaises(prtg.AuthenticationError):
+            prtg.PrtgApi(host="x", user="u")  # no passhash, no apikey
+
+    @patch("prtg.requests.get")
+    def test_apikey_used_in_params(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        prtg.PrtgApi(host="x", apikey="MYTOKEN")
+        # The first call's params should include the apitoken
+        call = mock_get.call_args_list[0]
+        params = call.kwargs["params"]
+        self.assertEqual(params["apitoken"], "MYTOKEN")
+        self.assertNotIn("username", params)
+
+    @patch("prtg.requests.get")
+    def test_userpass_used_in_params(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        prtg.PrtgApi(host="x", user="bob", passhash="abc123")
+        call = mock_get.call_args_list[0]
+        params = call.kwargs["params"]
+        self.assertEqual(params["username"], "bob")
+        self.assertEqual(params["passhash"], "abc123")
+        self.assertNotIn("apitoken", params)
+
+    @patch("prtg.requests.get")
+    def test_401_raises_authentication_error(self, mock_get):
+        mock_get.return_value = make_response(text="nope", status_code=401)
+        with self.assertRaises(prtg.AuthenticationError):
+            prtg.PrtgApi(host="x", apikey="t")
+
+    @patch("prtg.requests.get")
+    def test_404_raises_resource_not_found(self, mock_get):
+        mock_get.return_value = make_response(text="", status_code=404)
+        with self.assertRaises(prtg.ResourceNotFound):
+            prtg.PrtgApi(host="x", apikey="t")
+
+    @patch("prtg.requests.get")
+    def test_400_raises_malformed(self, mock_get):
+        mock_get.return_value = make_response(text="", status_code=400)
+        with self.assertRaises(prtg.MalformedRequest):
+            prtg.PrtgApi(host="x", apikey="t")
+
+
+# ---------------------------------------------------------------------------
+# URL / parameter construction
+# ---------------------------------------------------------------------------
+
+
+class TestParameterEncoding(unittest.TestCase):
+    """
+    The biggest behavioural change in the refactor: values are sent via
+    ``params=`` so requests handles URL-encoding. These tests verify
+    callers can pass values with special characters without breaking
+    the request or injecting extra parameters.
+    """
+
+    def setUp(self) -> None:
+        prtg.GlobalArrays.allprobes.clear()
+        prtg.GlobalArrays.allgroups.clear()
+        prtg.GlobalArrays.alldevices.clear()
+        prtg.GlobalArrays.allsensors.clear()
+
+    def _make_api(self, mock_get) -> prtg.PrtgApi:
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        return prtg.PrtgApi(host="prtg.example.com", apikey="t")
+
+    @patch("prtg.requests.get")
+    def test_rename_passes_value_through_params(self, mock_get):
+        api = self._make_api(mock_get)
+        device = api.alldevices[0]
+        # Rename with a value containing spaces and an ampersand
+        device.rename("web & app server")
+        last_call = mock_get.call_args_list[-1]
+        self.assertEqual(last_call.kwargs["params"]["value"], "web & app server")
+        # The URL itself should NOT contain the raw &, because it's in params
+        self.assertNotIn("&value=", last_call.args[0])
+
+    @patch("prtg.requests.get")
+    def test_pause_message_handled(self, mock_get):
+        api = self._make_api(mock_get)
+        device = api.alldevices[0]
+        device.pause(duration=60, message="rolling out v2.0 — please wait")
+        last_call = mock_get.call_args_list[-1]
+        params = last_call.kwargs["params"]
+        self.assertEqual(params["pausemsg"], "rolling out v2.0 — please wait")
+        self.assertEqual(params["duration"], 60)
+
+    @patch("prtg.requests.get")
+    def test_set_property_with_special_chars(self, mock_get):
+        api = self._make_api(mock_get)
+        device = api.alldevices[0]
+        # A tag string containing characters that would have broken the
+        # old string-format approach
+        device.set_property("tags", "env=prod team=ops alert=on&off")
+        last_call = mock_get.call_args_list[-1]
+        self.assertEqual(
+            last_call.kwargs["params"]["value"],
+            "env=prod team=ops alert=on&off",
+        )
+
+    @patch("prtg.requests.get")
+    def test_add_tags_deduplicates(self, mock_get):
+        api = self._make_api(mock_get)
+        device = api.alldevices[0]
+        # First call returns existing tags (from get_property)
+        mock_get.return_value = make_response(
+            text="<result>foo bar</result>",
+        )
+        device.add_tags(["bar", "baz"])
+        # The last call is set_property — tags value should be deduped
+        last_call = mock_get.call_args_list[-1]
+        self.assertEqual(last_call.kwargs["params"]["value"], "foo bar baz")
+
+    @patch("prtg.requests.get")
+    def test_pause_endpoint_choice(self, mock_get):
+        """duration=0 hits pause.htm, duration>0 hits pauseobjectfor.htm."""
+        api = self._make_api(mock_get)
+        device = api.alldevices[0]
+
+        device.pause()  # duration=0
+        endpoint = mock_get.call_args_list[-1].args[0]
+        self.assertTrue(endpoint.endswith("pause.htm"))
+
+        device.pause(duration=300)
+        endpoint = mock_get.call_args_list[-1].args[0]
+        self.assertTrue(endpoint.endswith("pauseobjectfor.htm"))
+
+    @patch("prtg.requests.get")
+    def test_verify_ssl_propagated_false(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        prtg.PrtgApi(host="x", apikey="t", verify_ssl=False)
+        self.assertEqual(mock_get.call_args_list[0].kwargs["verify"], False)
+
+    @patch("prtg.requests.get")
+    def test_verify_ssl_propagated_true(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        prtg.PrtgApi(host="x", apikey="t", verify_ssl=True)
+        self.assertEqual(mock_get.call_args_list[0].kwargs["verify"], True)
+
+    @patch("prtg.requests.get")
+    def test_verify_ssl_default_false(self, mock_get):
+        """Default matches the original module's behaviour."""
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        prtg.PrtgApi(host="x", apikey="t")
+        self.assertEqual(mock_get.call_args_list[0].kwargs["verify"], False)
+
+
+# ---------------------------------------------------------------------------
+# Refresh / reconciliation
+# ---------------------------------------------------------------------------
+
+
+class TestRefresh(unittest.TestCase):
+    """
+    Exercise _reconcile_children through the various refresh() paths.
+    A sensor is added, another is removed, a device disappears — the
+    in-memory tree should match the new XML afterwards.
+    """
+
+    def setUp(self) -> None:
+        prtg.GlobalArrays.allprobes.clear()
+        prtg.GlobalArrays.allgroups.clear()
+        prtg.GlobalArrays.alldevices.clear()
+        prtg.GlobalArrays.allsensors.clear()
+
+    @patch("prtg.requests.get")
+    def test_device_refresh_adds_and_removes_sensors(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        web = next(d for d in api.alldevices if d.name == "web-01")
+        self.assertEqual(
+            {s.name for s in web.sensors}, {"Ping", "HTTP"}
+        )
+
+        # Now return the updated tree on refresh — but the device-level
+        # refresh fetches just the device subtree, so build a small one
+        device_only_xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <sensortree><nodes><device>
+            <id>100</id><name>web-01</name><active>true</active>
+            <host>10.0.0.1</host>
+            <sensor><id>1000</id><name>Ping</name>
+                <active>true</active><status>Up</status></sensor>
+            <sensor><id>1002</id><name>CPU</name>
+                <active>true</active><status>Up</status></sensor>
+        </device></nodes></sensortree>
+        """
+        mock_get.return_value = make_response(text=device_only_xml)
+        web.refresh()
+        self.assertEqual(
+            {s.name for s in web.sensors}, {"Ping", "CPU"}
+        )
+
+    @patch("prtg.requests.get")
+    def test_group_refresh_removes_missing_devices(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        group = api.allgroups[0]
+        self.assertEqual(len(group.devices), 2)
+
+        group_only_xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <sensortree><nodes><group>
+            <id>10</id><name>Servers</name><active>true</active>
+            <device>
+                <id>100</id><name>web-01</name><active>true</active>
+                <host>10.0.0.1</host>
+            </device>
+        </group></nodes></sensortree>
+        """
+        mock_get.return_value = make_response(text=group_only_xml)
+        group.refresh()
+        self.assertEqual(len(group.devices), 1)
+        self.assertEqual(group.devices[0].name, "web-01")
+
+
+# ---------------------------------------------------------------------------
+# clone()  — the user's original bug
+# ---------------------------------------------------------------------------
+
+
+class TestClone(unittest.TestCase):
+    """
+    Original failure was:
+        AttributeError: 'NoneType' object has no attribute 'history'
+    Actually: req.history was empty (no redirects), so req.history[-1]
+    raised IndexError, OR PRTG returned a login-page URL with the id
+    embedded in a ``loginurl`` parameter. We now handle multiple shapes
+    including the SSO redirect chain seen in real-world Azure-AD-backed
+    PRTG installations.
+    """
+
+    def setUp(self) -> None:
+        prtg.GlobalArrays.allprobes.clear()
+        prtg.GlobalArrays.allgroups.clear()
+        prtg.GlobalArrays.alldevices.clear()
+        prtg.GlobalArrays.allsensors.clear()
+
+    @patch("prtg.requests.get")
+    def test_clone_with_classic_redirect(self, mock_get):
+        # 302 → final URL has ?id=9999
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        device = api.alldevices[0]
+
+        mock_get.return_value = make_response(
+            text="ok",
+            url="https://prtg.example.com/device.htm?id=9999",
+            history_urls=[
+                "https://prtg.example.com/api/duplicateobject.htm?id=100&name=foo&targetid=10",
+            ],
+        )
+        new_id = device.clone("new-name", "10")
+        self.assertEqual(new_id, "9999")
+
+    @patch("prtg.requests.get")
+    def test_clone_with_sso_redirect_chain(self, mock_get):
+        """
+        Real-world Azure-AD SSO redirect chain captured from a production
+        PRTG install (blackwall.io, June 2026). The chain goes:
+
+          1. duplicateobject.htm  (request URL — has SOURCE id, must skip)
+          2. sensor.htm?id=NNN    (the new id — direct redirect from PRTG)
+          3. login.htm?loginurl=/sensor.htm?id=NNN
+          4. Azure AD authorize  (no id at all)
+          5. /cb?error=login_required  (no id)
+          6. local_login.htm?loginurl=/sensor.htm?id=NNN  (final, id in loginurl)
+
+        Our extractor must NOT pick up the source id from URL 1, must
+        find the new id from one of 2/3/6, and must skip 4/5.
+        """
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        device = api.alldevices[0]
+
+        mock_get.return_value = make_response(
+            text="<html>...</html>",
+            url=(
+                "https://prtg.example.com/public/local_login.htm"
+                "?loginurl=%2Fsensor.htm%3Fid%3D39338"
+            ),
+            history_urls=[
+                "https://prtg.example.com/api/duplicateobject.htm?id=100&name=foo&targetid=10",
+                "https://prtg.example.com/sensor.htm?id=39338",
+                "https://prtg.example.com/public/login.htm?loginurl=%2Fsensor.htm%3Fid%3D39338&errorid=0",
+                "https://login.microsoftonline.com/abc/oauth2/v2.0/authorize?response_type=code",
+                "https://prtg.example.com/cb?error=login_required&state=xxx",
+            ],
+        )
+        new_id = device.clone("new-name", "10")
+        self.assertEqual(new_id, "39338")
+
+    @patch("prtg.requests.get")
+    def test_clone_skips_source_id_in_request_url(self, mock_get):
+        """
+        Critical: must NOT pick up the source id from the original
+        duplicateobject.htm request URL (which has ?id=<source>).
+        """
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        device = api.alldevices[0]  # device id is "100"
+
+        # Final URL is the duplicateobject request itself (PRTG returned
+        # immediately without redirecting). No "real" new id available.
+        mock_get.return_value = make_response(
+            text="ok",
+            url="https://prtg.example.com/api/duplicateobject.htm?id=100&name=foo&targetid=10",
+        )
+        # Should NOT return "100" (that's the source). Should return None.
+        self.assertIsNone(device.clone("new-name", "10"))
+
+    @patch("prtg.requests.get")
+    def test_clone_with_login_page_response(self, mock_get):
+        """The Paessler-KB-documented shape: final URL is a login page."""
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        device = api.alldevices[0]
+
+        # No redirect; PRTG returned a login page whose query string
+        # contains the new id inside loginurl=.
+        mock_get.return_value = make_response(
+            text="<html>Login</html>",
+            url=(
+                "https://prtg.example.com/public/login.htm"
+                "?loginurl=%2Fobject.htm%3Fid%3D9999&errormsg="
+            ),
+            history_urls=None,
+        )
+        new_id = device.clone("new-name", "10")
+        self.assertEqual(new_id, "9999")
+
+    @patch("prtg.requests.get")
+    def test_clone_with_direct_id_url(self, mock_get):
+        """No redirects, but the final URL has ?id=NNN directly."""
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        device = api.alldevices[0]
+
+        mock_get.return_value = make_response(
+            text="ok",
+            url="https://prtg.example.com/device.htm?id=8888",
+        )
+        self.assertEqual(device.clone("n", "10"), "8888")
+
+    @patch("prtg.requests.get")
+    def test_clone_with_unparseable_response_returns_none(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        device = api.alldevices[0]
+
+        mock_get.return_value = make_response(
+            text="progress info only",
+            url="https://prtg.example.com/api/duplicateobject.htm",
+        )
+        self.assertIsNone(device.clone("n", "10"))
+
+
+# ---------------------------------------------------------------------------
+# Channel value parsing
+# ---------------------------------------------------------------------------
+
+
+class TestChannelLastValueParsing(unittest.TestCase):
+    """The original parser exploded on values without units or negatives."""
+
+    def _make_channel(self, lastvalue: str) -> prtg.Channel:
+        # Build a minimal channelsoup
+        from bs4 import BeautifulSoup
+        xml = f"""<item>
+            <objid>1</objid>
+            <name>c</name>
+            <lastvalue>{lastvalue}</lastvalue>
+        </item>"""
+        soup = BeautifulSoup(xml, "lxml").item
+        confdata = prtg.ConfData("h", "443", None, None, "https", "t", True, 30.0)
+        return prtg.Channel(soup, sensorid="1", confdata=confdata)
+
+    def test_value_with_unit(self):
+        c = self._make_channel("42 ms")
+        self.assertEqual(c.lastvalue_int, 42)
+        self.assertEqual(c.unit, "ms")
+
+    def test_value_without_unit(self):
+        # The original code raised IndexError here
+        c = self._make_channel("42")
+        self.assertEqual(c.lastvalue_int, 42)
+        self.assertEqual(c.unit, "")
+
+    def test_value_with_comma_thousands(self):
+        c = self._make_channel("1,234 kbit/s")
+        self.assertEqual(c.lastvalue_int, 1234)
+
+    def test_value_with_decimal(self):
+        c = self._make_channel("42.5 ms")
+        self.assertEqual(c.lastvalue_float, 42.5)
+
+    def test_non_numeric_value_doesnt_crash(self):
+        # The original code didn't crash here, but didn't set any of the
+        # numeric attrs either. Make sure we behave the same way.
+        c = self._make_channel("OK")
+        self.assertFalse(hasattr(c, "lastvalue_int"))
+
+
+# ---------------------------------------------------------------------------
+# Historic data
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Historic data
+# ---------------------------------------------------------------------------
+
+
+class TestHistoricDataOnSensor(unittest.TestCase):
+    """Preferred path: sensor.get_historic_data() inherited from BaseConfig."""
+
+    def setUp(self) -> None:
+        prtg.GlobalArrays.allprobes.clear()
+        prtg.GlobalArrays.allgroups.clear()
+        prtg.GlobalArrays.alldevices.clear()
+        prtg.GlobalArrays.allsensors.clear()
+
+    @patch("prtg.requests.get")
+    def test_sensor_get_historic_data(self, mock_get):
+        from datetime import datetime
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        sensor = api.allsensors[0]
+
+        csv_text = (
+            'Date Time,"Traffic In (kbit/s)","Traffic Out (kbit/s)"\n'
+            '"05/29/2026 10:00:00 AM",100,200\n'
+            '"05/29/2026 10:05:00 AM",110,210\n'
+        )
+        mock_get.return_value = make_response(text=csv_text)
+        data = sensor.get_historic_data(
+            startdate="2026-05-29-00-00-00",
+            enddate="2026-05-29-23-59-59",
+            timeaverage=300,
+        )
+        self.assertEqual(len(data["Date Time"]), 2)
+        self.assertEqual(data["Traffic In (kbit/s)"], ["100", "110"])
+        self.assertEqual(data["Date Time"][0], datetime(2026, 5, 29, 10, 0, 0))
+
+        # Verify the request used the sensor's own id, not a manually-passed one
+        last_call = mock_get.call_args_list[-1]
+        self.assertEqual(last_call.kwargs["params"]["id"], sensor.id)
+
+    @patch("prtg.requests.get")
+    def test_skips_summary_footer_row(self, mock_get):
+        """PRTG appends a footer like 'Sums (of 30 values)' that isn't a date."""
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        sensor = api.allsensors[0]
+
+        csv_text = (
+            'Date Time,"Traffic In (kbit/s)","Traffic Out (kbit/s)"\n'
+            '"05/29/2026 10:00:00 AM",100,200\n'
+            '"05/29/2026 10:05:00 AM",110,210\n'
+            '"05/29/2026 10:10:00 AM",120,220\n'
+            '"Sums (of 30 values)",330,630\n'
+        )
+        mock_get.return_value = make_response(text=csv_text)
+        data = sensor.get_historic_data(
+            startdate="2026-05-29-00-00-00",
+            enddate="2026-05-29-23-59-59",
+            timeaverage=300,
+        )
+        # Footer should be skipped entirely; lists stay aligned at length 3
+        self.assertEqual(len(data["Date Time"]), 3)
+        self.assertEqual(len(data["Traffic In (kbit/s)"]), 3)
+        self.assertEqual(len(data["Traffic Out (kbit/s)"]), 3)
+        # Footer's numeric cells must NOT appear
+        self.assertNotIn("330", data["Traffic In (kbit/s)"])
+
+    @patch("prtg.requests.get")
+    def test_skips_averages_footer_row(self, mock_get):
+        """Variant footer: 'Averages (of N values)'."""
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        sensor = api.allsensors[0]
+
+        csv_text = (
+            'Date Time,"Traffic In (kbit/s)"\n'
+            '"05/29/2026 10:00:00 AM",100\n'
+            '"Averages (of 12 values)",105\n'
+        )
+        mock_get.return_value = make_response(text=csv_text)
+        data = sensor.get_historic_data(
+            startdate="2026-05-29-00-00-00",
+            enddate="2026-05-29-23-59-59",
+            timeaverage=300,
+        )
+        self.assertEqual(len(data["Date Time"]), 1)
+        self.assertEqual(data["Traffic In (kbit/s)"], ["100"])
+
+    @patch("prtg.requests.get")
+    def test_datetime_argument_auto_formatted(self, mock_get):
+        from datetime import datetime
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        sensor = api.allsensors[0]
+
+        mock_get.return_value = make_response(text='Date Time\n"01/01/2026 12:00:00 PM"\n')
+        sensor.get_historic_data(
+            startdate=datetime(2026, 1, 1),
+            enddate=datetime(2026, 1, 2),
+            timeaverage=0,
+        )
+        params = mock_get.call_args.kwargs["params"]
+        self.assertEqual(params["sdate"], "2026-01-01-00-00-00")
+        self.assertEqual(params["edate"], "2026-01-02-00-00-00")
+
+    @patch("prtg.requests.get")
+    def test_strips_date_time_interval_annotation(self, mock_get):
+        """Date Time cells may have a trailing ' - <interval>' suffix."""
+        from datetime import datetime
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        sensor = api.allsensors[0]
+
+        csv_text = (
+            'Date Time,Value\n'
+            '"05/29/2026 10:00:00 AM - 05/29/2026 10:05:00 AM",100\n'
+        )
+        mock_get.return_value = make_response(text=csv_text)
+        data = sensor.get_historic_data(
+            startdate="2026-05-29-00-00-00",
+            enddate="2026-05-29-23-59-59",
+            timeaverage=300,
+        )
+        self.assertEqual(data["Date Time"][0], datetime(2026, 5, 29, 10, 0, 0))
+
+
+class TestHistoricDataDeprecated(unittest.TestCase):
+    """The PrtgHistoricData shim still works but warns."""
+
+    def test_construction_warns(self):
+        with self.assertWarns(DeprecationWarning):
+            prtg.PrtgHistoricData(host="x", apikey="t")
+
+    @patch("prtg.requests.get")
+    def test_legacy_class_still_parses(self, mock_get):
+        import warnings as _w
+        from datetime import datetime
+        csv_text = (
+            'Date Time,"Traffic In"\n'
+            '"05/29/2026 10:00:00 AM",100\n'
+            '"Sums (of 30 values)",100\n'
+        )
+        mock_get.return_value = make_response(text=csv_text)
+
+        with _w.catch_warnings():
+            _w.simplefilter("ignore", DeprecationWarning)
+            h = prtg.PrtgHistoricData(host="x", apikey="t")
+
+        data = h.get_historic_data(
+            objid=1000,
+            startdate="2026-05-29-00-00-00",
+            enddate="2026-05-29-23-59-59",
+            timeaverage=300,
+        )
+        # Footer-skip applies here too via the shared helper
+        self.assertEqual(len(data["Date Time"]), 1)
+
+    def test_format_date(self):
+        from datetime import datetime
+        self.assertEqual(
+            prtg.PrtgHistoricData.format_date(datetime(2026, 1, 2, 3, 4, 5)),
+            "2026-01-02-03-04-05",
+        )
+
+
+# ---------------------------------------------------------------------------
+# delete()
+# ---------------------------------------------------------------------------
+
+
+class TestDelete(unittest.TestCase):
+    def setUp(self) -> None:
+        prtg.GlobalArrays.allprobes.clear()
+        prtg.GlobalArrays.allgroups.clear()
+        prtg.GlobalArrays.alldevices.clear()
+        prtg.GlobalArrays.allsensors.clear()
+
+    @patch("prtg.requests.get")
+    def test_delete_root_raises(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        api.type = "Root"
+        with self.assertRaises(prtg.PrtgError):
+            api.delete(confirm=False)
+
+    @patch("prtg.requests.get")
+    def test_delete_channel_raises(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        from bs4 import BeautifulSoup
+        channelsoup = BeautifulSoup(
+            "<item><objid>1</objid><name>c</name></item>", "lxml"
+        ).item
+        c = prtg.Channel(channelsoup, sensorid="1", confdata=api.confdata)
+        with self.assertRaises(prtg.PrtgError):
+            c.delete()
+
+    @patch("prtg.requests.get")
+    def test_delete_calls_endpoint_with_approve(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        device = api.alldevices[0]
+        device.delete(confirm=False)
+        last_call = mock_get.call_args_list[-1]
+        self.assertTrue(last_call.args[0].endswith("deleteobject.htm"))
+        self.assertEqual(last_call.kwargs["params"]["approve"], 1)
+        self.assertEqual(last_call.kwargs["params"]["id"], device.id)
+
+
+# ---------------------------------------------------------------------------
+# Timeout / connection errors
+# ---------------------------------------------------------------------------
+
+
+class TestTimeouts(unittest.TestCase):
+    def setUp(self) -> None:
+        prtg.GlobalArrays.allprobes.clear()
+        prtg.GlobalArrays.allgroups.clear()
+        prtg.GlobalArrays.alldevices.clear()
+        prtg.GlobalArrays.allsensors.clear()
+
+    @patch("prtg.requests.get")
+    def test_timeout_passed_to_requests(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        prtg.PrtgApi(host="x", apikey="t", timeout=5.0)
+        self.assertEqual(mock_get.call_args_list[0].kwargs["timeout"], 5.0)
+
+    @patch("prtg.requests.get")
+    def test_timeout_default_30(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        prtg.PrtgApi(host="x", apikey="t")
+        self.assertEqual(mock_get.call_args_list[0].kwargs["timeout"], 30.0)
+
+    @patch("prtg.requests.get")
+    def test_timeout_exception_wrapped(self, mock_get):
+        import requests as _requests
+        mock_get.side_effect = _requests.exceptions.Timeout("slow")
+        with self.assertRaises(prtg.PrtgError) as ctx:
+            prtg.PrtgApi(host="x", apikey="t", timeout=1.0)
+        self.assertIn("timed out", str(ctx.exception))
+
+    @patch("prtg.requests.get")
+    def test_connection_error_wrapped(self, mock_get):
+        import requests as _requests
+        mock_get.side_effect = _requests.exceptions.ConnectionError("refused")
+        with self.assertRaises(prtg.PrtgError) as ctx:
+            prtg.PrtgApi(host="x", apikey="t")
+        self.assertIn("Connection to PRTG failed", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# Login-page-on-200 detection
+# ---------------------------------------------------------------------------
+
+
+class TestLoginPageDetection(unittest.TestCase):
+    """PRTG sometimes returns 200 with a login page on auth failure."""
+
+    def setUp(self) -> None:
+        prtg.GlobalArrays.allprobes.clear()
+        prtg.GlobalArrays.allgroups.clear()
+        prtg.GlobalArrays.alldevices.clear()
+        prtg.GlobalArrays.allsensors.clear()
+
+    @patch("prtg.requests.get")
+    def test_login_page_on_200_raises_auth_error(self, mock_get):
+        mock_get.return_value = make_response(
+            text="<html>Login</html>",
+            url="https://prtg.example.com/public/login.htm?errormsg=invalid",
+        )
+        with self.assertRaises(prtg.AuthenticationError):
+            prtg.PrtgApi(host="x", apikey="bad")
+
+    @patch("prtg.requests.get")
+    def test_clone_bypasses_login_check(self, mock_get):
+        """clone() must accept login-page responses since the id is in the URL."""
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        device = api.alldevices[0]
+
+        mock_get.return_value = make_response(
+            text="<html>Login</html>",
+            url=(
+                "https://prtg.example.com/public/login.htm"
+                "?loginurl=%2Fobject.htm%3Fid%3D7777&errormsg="
+            ),
+        )
+        # Should not raise — clone passes check_login_page=False
+        self.assertEqual(device.clone("n", "10"), "7777")
+
+
+# ---------------------------------------------------------------------------
+# save_graph is now on BaseConfig and inherited by all objects
+# ---------------------------------------------------------------------------
+
+
+class TestInheritedSaveGraph(unittest.TestCase):
+    def setUp(self) -> None:
+        prtg.GlobalArrays.allprobes.clear()
+        prtg.GlobalArrays.allgroups.clear()
+        prtg.GlobalArrays.alldevices.clear()
+        prtg.GlobalArrays.allsensors.clear()
+
+    @patch("prtg.requests.get")
+    def test_device_can_save_graph(self, mock_get):
+        """Now that save_graph is on BaseConfig, devices/groups can use it too."""
+        import tempfile, os
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        device = api.alldevices[0]
+
+        # Mock the binary download
+        binary_resp = make_response(text="")
+        binary_resp.iter_content = lambda chunk_size=8192: iter([b"FAKEPNG"])
+        mock_get.return_value = binary_resp
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".svg") as f:
+            tmppath = f.name
+        try:
+            device.save_graph(graphid="0", filepath=tmppath, size="M")
+            with open(tmppath, "rb") as f:
+                self.assertEqual(f.read(), b"FAKEPNG")
+        finally:
+            os.unlink(tmppath)
+
+    @patch("prtg.requests.get")
+    def test_sensor_acknowledge_calls_get_status(self, mock_get):
+        """Sensor.acknowledge overrides the base to refresh status afterwards."""
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        api = prtg.PrtgApi(host="x", apikey="t")
+        sensor = api.allsensors[0]
+
+        mock_get.return_value = make_response(text="<result>Up</result>")
+        sensor.acknowledge("test ack")
+        # Two calls: acknowledgealarm.htm then getobjectstatus.htm
+        endpoints = [c.args[0] for c in mock_get.call_args_list[-2:]]
+        self.assertTrue(endpoints[0].endswith("acknowledgealarm.htm"))
+        self.assertTrue(endpoints[1].endswith("getobjectstatus.htm"))
+
+
+# ---------------------------------------------------------------------------
+# Deprecated lowercase aliases
+# ---------------------------------------------------------------------------
+
+
+class TestDeprecatedAliases(unittest.TestCase):
+    """The old prtg_api / prtg_device / prtg_sensor names still work."""
+
+    def setUp(self) -> None:
+        prtg.GlobalArrays.allprobes.clear()
+        prtg.GlobalArrays.allgroups.clear()
+        prtg.GlobalArrays.alldevices.clear()
+        prtg.GlobalArrays.allsensors.clear()
+
+    @patch("prtg.requests.get")
+    def test_prtg_api_alias_warns(self, mock_get):
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        with self.assertWarns(DeprecationWarning):
+            prtg.prtg_api(host="x", apikey="t")
+
+    @patch("prtg.requests.get")
+    def test_prtg_api_alias_returns_working_object(self, mock_get):
+        """Alias is a true subclass — instances behave identically."""
+        import warnings as _w
+        mock_get.return_value = make_response(text=SENSORTREE_XML)
+        with _w.catch_warnings():
+            _w.simplefilter("ignore", DeprecationWarning)
+            api = prtg.prtg_api(host="x", apikey="t")
+        # All the usual attributes work
+        self.assertIsInstance(api, prtg.PrtgApi)
+        self.assertEqual(len(api.probes), 1)
+        self.assertEqual(api.probes[0].name, "Local Probe")
+
+    @patch("prtg.requests.get")
+    def test_prtg_device_alias_warns(self, mock_get):
+        # PrtgDevice's constructor fetches a tree, so we need to provide a
+        # device-shaped XML response.
+        device_only_xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <sensortree><nodes><device>
+            <id>100</id><name>web-01</name><active>true</active>
+            <host>10.0.0.1</host>
+        </device></nodes></sensortree>
+        """
+        mock_get.return_value = make_response(text=device_only_xml)
+        with self.assertWarns(DeprecationWarning):
+            prtg.prtg_device(host="x", apikey="t", deviceid=100)
+
+    @patch("prtg.requests.get")
+    def test_prtg_sensor_alias_warns(self, mock_get):
+        sensor_only_xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <sensortree><nodes><sensor>
+            <id>1000</id><name>Ping</name><active>true</active>
+            <status>Up</status>
+        </sensor></nodes></sensortree>
+        """
+        # Constructor calls get_channels too, which needs another response.
+        # Easier to just patch out get_channels.
+        mock_get.return_value = make_response(text=sensor_only_xml)
+        with patch.object(prtg.PrtgSensor, "get_channels"):
+            with self.assertWarns(DeprecationWarning):
+                prtg.prtg_sensor(host="x", apikey="t", sensorid=1000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PRTG module refactor — change summary

This document records what changed during the cleanup pass so future diffs against the original `prtg.py` are easy to understand.

## Bugs fixed

1. **`prtg_api.refresh` typo** — `self.alldevice.remove(...)` was a typo for `alldevices`. Refresh now goes through `_reconcile_children`, which uses the correct list.
2. **`prtg_device.refresh` undefined `deviceid`** — now stores `self.deviceid` in `__init__` and uses it.
3. **`prtg_sensor.refresh` undefined `sensorsoup`** — now references the local `sensor_node` correctly.
4. **`self.AuthenticationError` etc. attribute errors** — exceptions are now module-level classes (`PrtgError`, `AuthenticationError`, `ResourceNotFound`, `MalformedRequest`) and are raised directly, not as attributes of `self`.
5. **`delete()` on root silently returned a string** — now raises `PrtgError`.
6. **`Channel.delete()` returned a string** — now raises `PrtgError`.
7. **`clone()` crashed on PRTG instances that don't return a redirect** — this is the bug that prompted the audit. Original code did `req.history[-1].url` which raised `AttributeError`/`IndexError` when history was empty. Now uses `_extract_new_id()` which walks the entire redirect chain, prefers object-page URLs (`sensor.htm`, `device.htm`, etc.) over login pages, and explicitly skips the `duplicateobject.htm` request URL (which contains the *source* object's id, not the new id). Verified against a real Azure-AD-backed PRTG install with a 6-hop SSO redirect chain.
8. **`XMLParsedAsHTMLWarning` was being suppressed instead of fixed** — every `BeautifulSoup(req.text, "lxml")` call that parses PRTG XML now uses `"xml"` (i.e. `lxml-xml`). The warning is no longer emitted, so the global filter and the import are gone.
9. **No request timeouts** — a hung PRTG server would block forever. All requests now use `timeout=30.0` by default (configurable on each constructor). Timeouts and connection errors are wrapped as `PrtgError`.
10. **Login-page on 200 was not detected** — PRTG sometimes returns 200 with an HTML login page on auth failure instead of 401. `get_request` now detects this and raises `AuthenticationError`. `clone()` opts out via `check_login_page=False` since its success response legitimately lands on a login page.
11. **`Sensor` and `PrtgSensor` had duplicated `save_graph`/`get_details`/`acknowledge` bodies** — moved to `BaseConfig`, so devices and groups can `save_graph()` too. `Sensor.acknowledge` overrides to also refresh status.
12. **`PrtgSensor.acknowledge` didn't refresh status (`Sensor.acknowledge` did)** — now consistent via the shared base.
13. **`PrtgHistoricData` parser crashed on the summary footer row** — PRTG appends a footer like `"Sums (of 30 values)"` whose Date Time cell isn't a parseable timestamp. The original parser called `strptime` unconditionally and threw `ValueError`, and the previous try/except path could leave per-column lists misaligned because some cells from the footer row had already been appended before the date column. Fix: detect rows whose Date Time cell isn't a valid timestamp (footer pattern) and skip the entire row before appending anything. Also handles the `"Averages (of N values)"` variant.

## Correctness / safety improvements

14. **URL parameter encoding** — every API call now uses `requests`' `params=` kwarg instead of f-string concatenation. Tag names, pause messages, ack messages, rename values etc. with special characters (`&`, `=`, spaces, unicode) now work correctly and cannot inject extra query parameters.
15. **`verify_ssl` is now a connection parameter** — exposed on every constructor. Defaults to `False` to match the original module's behaviour (which always disabled verification). Pass `verify_ssl=True` to opt in to certificate verification.
16. **`timeout` is now a connection parameter** — defaults to 30 seconds. Configurable via the constructor.
17. **`urllib3` import modernised** — `requests.packages.urllib3` was deprecated; uses top-level `urllib3` now.
18. **`isinstance(x, datetime)`** instead of `type(x) == datetime`.
19. **`add_tags` deduplicates** — uses `dict.fromkeys` to preserve order and drop duplicates.
20. **`Channel._parse_lastvalue` handles edge cases** — empty values, missing units, non-numeric strings, negative numbers, scientific notation.
21. **`save_graph` uses `stream=True`** — properly streams binary content via `iter_content` instead of iterating a non-streamed response.
22. **Historic CSV parsing** — filters empty lines instead of hard-coded `[:-2]`.

## Backwards compatibility shims

23. **`PrtgHistoricData` → `sensor.get_historic_data()`** — historic data is a per-sensor operation, so the method now lives on `BaseConfig` and is available as `sensor.get_historic_data(startdate, enddate, timeaverage)`. The standalone class still works but emits `DeprecationWarning`. Both paths share the `_parse_historic_csv` helper, so the footer-skip fix applies to both.
24. **Deprecated lowercase class aliases** — `prtg_api`, `prtg_device`, `prtg_sensor` still work as drop-in replacements so existing scripts upgrade cleanly. Each emits a single `DeprecationWarning` on construction pointing to the new PascalCase name. The aliases will be removed in a future release. Use the warnings as a TODO list for migrating scripts at your own pace.

## Style / structural changes

25. **PEP-8 class names** — `prtg_api` → `PrtgApi`, `global_arrays` → `GlobalArrays`, etc.
26. **f-strings** replace every `"...{x}...".format(x=...)` call.
27. **`return value` / `raise Exception(...)`** — dropped the extra parens.
28. **PEP-8 spacing** — spaces after commas, blank lines between top-level definitions.
29. **`ConfData` NamedTuple** replaces the positional `confdata` tuple. Adding a field no longer breaks unpack sites.
30. **Type hints** added throughout (Python 3.10+ `X | None` syntax via `from __future__ import annotations` so it also works on 3.7+).
31. **Refresh logic deduplicated** — the "list IDs, walk new tree, refresh existing else create, prune missing" pattern is now `_reconcile_children`, used by every refresh method. The original code had four near-identical copies of this loop (one of which was the broken device refresh).
32. **`print()` removed from library code** — `Channel.pause`/`resume` now use `logging.warning`.
33. **`__str__` removed where redundant** — Python falls back to `__repr__`, and the repr now includes the class name.
34. **Builtin shadowing** — `id` parameter renamed to `oid` in `search_byid`.
35. **Docstring typos** — "Seperate" → "Separate".
36. **Constructor docstrings** updated to match actual signatures.

## Things deliberately left unchanged

- **Class-level `GlobalArrays` lists** — kept shared by design; the docstring now explicitly warns that multiple `PrtgApi` instances in one process will share state.
- **PRTG date format assumption** in historic data — still parses as US format. Documented in the docstring; changing this needs a real test against a non-default PRTG server.
- **`lxml` parser** — required as before. Now listed in `requirements.txt`.
- **`Channel.refresh` not cascaded from top-level refresh** — channels still need manual `sensor.get_channels()` to update. Same as original behaviour.
- **`set_property` updates local attribute optimistically** — if PRTG normalises or rejects the value, local state will drift from server. Document but don't change.
- **`delete()` uses bare `input()`** — will hang in non-interactive contexts. Workaround: always pass `confirm=False` in scripts.

## File structure

- `prtg.py` — the module
- `clone_probe.py` — standalone debug script to capture real PRTG clone responses
- `requirements.txt` — runtime dependencies
- `tests/test_prtg.py` — unittest suite (54 tests, all HTTP mocked)
- `CHANGES.md` — this file
- `README.md` — user-facing documentation

Run tests with: `python -m unittest discover tests` (or `python -m pytest tests/`)